### PR TITLE
highlight raw string literal

### DIFF
--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -1310,6 +1310,8 @@ if !exists("cpp_no_cpp11")
     syntax keyword cppSTLtype minutes
     syntax keyword cppSTLtype hours
 
+    "raw string literals
+    syntax region cppRawString matchgroup=cppRawDelimiter start=@\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(@ end=/)\z1"/ contains=@Spell
 endif " C++11
 
 if !exists("cpp_no_cpp14")
@@ -1354,5 +1356,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppSTLenum         Typedef
   HiLink cppSTLios          Function
   HiLink cppSTLcast         Statement " be consistent with official syntax
+  HiLink cppRawString       String 
+  HiLink cppRawDelimiter    Delimiter
   delcommand HiLink
 endif


### PR DESCRIPTION
I'm using vim 7.4 shipped with Ubuntu 14.04 LTS. I don't get correct highlight of raw string literals:

![screenshot from 2014-10-23 21 29 22](https://cloud.githubusercontent.com/assets/3337209/4753694/2aef797c-5ab9-11e4-9020-322f6b56bd57.png)

After this patch applied, things look like:

![screenshot from 2014-10-23 21 34 34](https://cloud.githubusercontent.com/assets/3337209/4753862/17a2a4ba-5aba-11e4-8c85-e00b674f978e.png)
