### PR TITLE
adding missing std::bit_xor

### DIFF
--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -134,6 +134,7 @@ syntax keyword cppSTLfunctional binary_negate
 syntax keyword cppSTLfunctional bit_and
 syntax keyword cppSTLfunctional bit_not
 syntax keyword cppSTLfunctional bit_or
+syntax keyword cppSTLfunctional bit_xor
 syntax keyword cppSTLfunctional divides
 syntax keyword cppSTLfunctional equal_to
 syntax keyword cppSTLfunctional greater


### PR DESCRIPTION
The syntax file was missing the `std::bit_xor` function http://en.cppreference.com/w/cpp/utility/functional/bit_xor