### PR TITLE
readme meant to have absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you don't have either Vundle or Pathogen installed, copy the cpp.vim file
 ```sh
 git clone https://github.com/octol/vim-cpp-enhanced-highlight.git /tmp
 mkdir -p ~/.vim/after/syntax/
-mv /tmp/vim-cpp-enhanced-highlight/after/syntax/cpp.vim after/syntax/cpp.vim
+mv /tmp/vim-cpp-enhanced-highlight/after/syntax/cpp.vim ~/.vim/after/syntax/cpp.vim
 rm -rf /tmp/vim-cpp-enhanced-highlight
 ```
 


### PR DESCRIPTION
would work from ~/.vim, but I think it was intended to work from any cwd