### PR TITLE
Improved the regex for templates

### DIFF
--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -37,19 +37,23 @@ syn match   cCustomParen    "(" contains=cParen contains=cCppParen
 syn match   cCustomFunc     "\w\+\s*(\@=" contains=cCustomParen
 hi def link cCustomFunc  Function
 
-" Template functions
-if exists('g:cpp_experimental_template_highlight') && g:cpp_experimental_template_highlight
-    syn region  cCustomAngleBrackets matchgroup=AngleBracketContents start="\v%(<operator\_s*)@<!%(%(\_i|template\_s*)@<=\<[<=]@!|\<@<!\<[[:space:]<=]@!)" end='>' contains=@cppSTLgroup,cppStructure,cType,cCustomClass,cCustomAngleBrackets,cNumbers
-    syn match   cCustomBrack    "<\|>" contains=cCustomAngleBrackets
-    syn match   cCustomTemplateFunc "\w\+\s*<.*>(\@=" contains=cCustomBrack,cCustomAngleBrackets
-    hi def link cCustomTemplateFunc  Function
-endif
-
 " Class and namespace scope
 if exists('g:cpp_class_scope_highlight') && g:cpp_class_scope_highlight
     syn match    cCustomScope    "::"
     syn match    cCustomClass    "\w\+\s*::" contains=cCustomScope
     hi def link cCustomClass Function  " disabled for now
+endif
+
+" Template functions
+if exists('g:cpp_experimental_template_highlight') && g:cpp_experimental_template_highlight
+    syn region  cCustomAngleBrackets matchgroup=AngleBracketContents start="\v%(<operator\_s*)@<!%(%(\_i|template\_s*)@<=\<[<=]@!|\<@<!\<[[:space:]<=]@!)" end='>' contains=@cppSTLgroup,cppStructure,cType,cCustomClass,cCustomAngleBrackets,cNumbers
+    syn match   cCustomBrack    "<\|>" contains=cCustomAngleBrackets
+
+    syn match   cCustomTemplateClass    "\w\{-,1}\s\{-}<[^:]\{-}>\(::\)\@=\(\w*(\)\@!" contains=cCustomScope,cCustomAngleBrackets
+    hi def link cCustomTemplateClass  cCustomClass
+
+    syn match   cCustomTemplateFunc "\(\(::\)\@<=\w\+\s*<.\{-}>\|\( \)\@<=\w\+\s*<[^:]\{-}>\)(\@=" contains=cCustomBrack 
+    hi def link cCustomTemplateFunc  cCustomFunc
 endif
 
 " Alternative syntax that is used in:
@@ -63,7 +67,7 @@ syn cluster cppSTLgroup     contains=cppSTLfunction,cppSTLfunctional,cppSTLconst
 " -----------------------------------------------------------------------------
 "  Standard library types and functions.
 "
-" Mainly based on the excellent STL Syntax vim script by
+" Mainly based on the excellent STL Syntax vim script by 
 " Mizuchi <ytj000@gmail.com>
 "   http://www.vim.org/scripts/script.php?script_id=4293
 " which in turn is based on the scripts
@@ -134,7 +138,6 @@ syntax keyword cppSTLfunctional binary_negate
 syntax keyword cppSTLfunctional bit_and
 syntax keyword cppSTLfunctional bit_not
 syntax keyword cppSTLfunctional bit_or
-syntax keyword cppSTLfunctional bit_xor
 syntax keyword cppSTLfunctional divides
 syntax keyword cppSTLfunctional equal_to
 syntax keyword cppSTLfunctional greater
@@ -1322,31 +1325,6 @@ if !exists("cpp_no_cpp14")
     "dynarray
     syntax keyword cppSTLtype dynarray
 
-    "helper type traits types
-    syntax keyword cppSTLtype remove_cv_t
-    syntax keyword cppSTLtype remove_const_t
-    syntax keyword cppSTLtype remove_volatile_t
-    syntax keyword cppSTLtype add_cv_t
-    syntax keyword cppSTLtype add_const_t
-    syntax keyword cppSTLtype add_volatile_t
-    syntax keyword cppSTLtype remove_reference_t
-    syntax keyword cppSTLtype add_lvalue_reference_t
-    syntax keyword cppSTLtype add_rvalue_reference_t
-    syntax keyword cppSTLtype remove_pointer_t
-    syntax keyword cppSTLtype add_pointer_t
-    syntax keyword cppSTLtype remove_extent_t
-    syntax keyword cppSTLtype remove_all_extents_t
-    syntax keyword cppSTLtype make_signed_t
-    syntax keyword cppSTLtype make_unsigned_t
-    syntax keyword cppSTLtype aligned_storage_t
-    syntax keyword cppSTLtype aligned_union_t
-    syntax keyword cppSTLtype decay_t
-    syntax keyword cppSTLtype enable_if_t
-    syntax keyword cppSTLtype conditional_t
-    syntax keyword cppSTLtype common_type_t
-    syntax keyword cppSTLtype underlying_type_t
-    syntax keyword cppSTLtype result_of_t
-
     "thread
     syntax keyword cppSTLtype shared_mutex
     syntax keyword cppSTLtype shared_lock
@@ -1385,7 +1363,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppSTLenum         Typedef
   HiLink cppSTLios          Function
   HiLink cppSTLcast         Statement " be consistent with official syntax
-  HiLink cppRawString       String
+  HiLink cppRawString       String 
   HiLink cppRawDelimiter    Delimiter
   delcommand HiLink
 endif

--- a/test/color.cpp
+++ b/test/color.cpp
@@ -1,0 +1,46 @@
+
+A::b A::getThing(Fred f);
+A::b A::getThing(Fred<T> f);
+A::b A::getThing<T>(Fred f);
+A::b A::getThing<T>(Fred<T> f);
+A::b A::getThing<T<t>>(Fred<T> f);
+A::b A::getThing<T<t>::List>(Fred<T> f);
+
+A::b A<T>::getThing(Fred f);
+A::b A<T>::getThing(Fred<T> f);
+A::b A<T>::getThing<T>(Fred f);
+A::b A<T>::getThing<T>(Fred<T> f);
+A::b A<T>::getThing<T<t>>(Fred<T> f);
+A::b A<T>::getThing<T<t>::List>(Fred<T> f);
+
+A<T>::b A::getThing(Fred f);
+A<T>::b A::getThing(Fred<T> f);
+A<T>::b A::getThing<T>(Fred f);
+A<T>::b A::getThing<T>(Fred<T> f);
+A<T>::b A::getThing<T<t>::List>(Fred<T> f);
+
+A<T>::b A<T>::getThing(Fred f);
+A<T>::b A<T>::getThing(Fred<T> f);
+A<T>::b A<T>::getThing<T>(Fred f);
+A<T>::b A<T>::getThing<T>(Fred<T> f);
+A<T>::b A<T>::getThing<T<t>::List>(Fred<T> f);
+
+A::b getThing(Fred f);
+A::b getThing(Fred<T> f);
+A::b getThing<T>(Fred f);
+A::b getThing<T>(Fred<T> f);
+A::b getThing<T<t>>(Fred<T> f);
+A::b getThing<T<t>::List>(Fred<T> f);
+
+A<T>::b getThing(Fred f);
+A<T>::b getThing(Fred<T> f);
+A<T>::b getThing<T>(Fred f);
+A<T>::b getThing<T>(Fred<T> f);
+A<T>::b getThing<T<t>>(Fred<T> f);
+A<T>::b getThing<T<t>::List>(Fred<T> f);
+
+//Template function:
+//\(\(::\)\@<=\w\+\s*<.\{-}>\|\( \)\@<=\w\+\s*<[^:]\{-}>\)(\@=/g
+
+//Template class:
+//\w\{-,1}\s\{-}<[^:]\{-}>\(::\)\@=\(\w*(\)\@!/g


### PR DESCRIPTION
A test cpp file for template functions has been added.
The regex for template functions has been improved, it covers most of the cases.
In addition a regex for template classes has been added. It works correctly in most cases.

These regex fail on the last of line of the last two sets of the tests. The template function is not recognised and the template class' is too wide.