### PR TITLE
Recognize container_type typedef of STL adaptors

### DIFF
--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -622,6 +622,7 @@ syntax keyword cppSTLtype const_mem_fun_ref_t
 syntax keyword cppSTLtype const_mem_fun_t
 syntax keyword cppSTLtype const_pointer
 syntax keyword cppSTLtype const_reference
+syntax keyword cppSTLtype container_type
 syntax keyword cppSTLtype deque
 syntax keyword cppSTLtype difference_type
 syntax keyword cppSTLtype div_t


### PR DESCRIPTION
STL adaptors like stack and queue provide the typedef
of the underlying container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/octol/vim-cpp-enhanced-highlight/28)
<!-- Reviewable:end -->
