### PR TITLE
Add Member Variable Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Highlighting of class scope is disabled by default. To enable set
 let g:cpp_class_scope_highlight = 1
 ```
 
+Highlighting of member variables is disabled by default. To enable set
+```vim
+let g:cpp_member_variable_highlight = 1
+```
+
 There are two ways to hightlight template functions. Either
 ```vim
 let g:cpp_experimental_simple_template_highlight = 1

--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -23,6 +23,16 @@ syn match    cCustomFunc     "\w\+\s*(\@=" contains=cCustomParen
 hi def link cCustomFunc  Function
 
 " -----------------------------------------------------------------------------
+"  Highlight member variable names.
+" -----------------------------------------------------------------------------
+if exists('g:cpp_member_variable_highlight') && g:cpp_member_variable_highlight
+    syn match   cCustomDot    "\." contained
+    syn match   cCustomPtr    "->" contained
+    syn match   cCustomMemVar "\(\.\|->\)\w\+" contains=cCustomDot,cCustomPtr
+    hi def link cCustomMemVar Function
+endif
+
+" -----------------------------------------------------------------------------
 "  Source: aftersyntaxc.vim
 " -----------------------------------------------------------------------------
 

--- a/test/color2.cpp
+++ b/test/color2.cpp
@@ -10,7 +10,7 @@ class Class {
 };
 
 bool operator<(const ConnectionString& other) const {
-    return _string < other._string;
+    return this->_string < other._string;
 }
 
 class Class {


### PR DESCRIPTION
In the example below, the `bar` after `foo.` would be highlighted as a Function

``` C
struct Foo {
    int bar;
};
Foo foo;
foo.bar = 1;
```
