### PR TITLE
Add C++14 type traits helper aliases

### DIFF
--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -886,6 +886,30 @@ if !exists("cpp_no_cpp11")
     syntax keyword cppSTLtype true_type
     syntax keyword cppSTLtype false_type
     syntax keyword cppSTLfunction declval
+    " C++14 helper aliases for type traits.
+    syntax keyword cppSTLtype remove_cv_t
+    syntax keyword cppSTLtype remove_const_t
+    syntax keyword cppSTLtype remove_volatile_t
+    syntax keyword cppSTLtype add_cv_t
+    syntax keyword cppSTLtype add_const_t
+    syntax keyword cppSTLtype add_volatile_t
+    syntax keyword cppSTLtype remove_reference_t
+    syntax keyword cppSTLtype add_lvalue_reference_t
+    syntax keyword cppSTLtype add_rvalue_reference_t
+    syntax keyword cppSTLtype remove_pointer_t
+    syntax keyword cppSTLtype add_pointer_t
+    syntax keyword cppSTLtype make_signed_t
+    syntax keyword cppSTLtype make_unsigned_t
+    syntax keyword cppSTLtype remove_extent_t
+    syntax keyword cppSTLtype remove_all_extents_t
+    syntax keyword cppSTLtype aligned_storage_t
+    syntax keyword cppSTLtype aligned_union_t
+    syntax keyword cppSTLtype decay_t
+    syntax keyword cppSTLtype enable_if_t
+    syntax keyword cppSTLtype conditional_t
+    syntax keyword cppSTLtype common_type_t
+    syntax keyword cppSTLtype underlying_type_t
+    syntax keyword cppSTLtype result_of_t
 
     syntax keyword cppSTLconstant piecewise_construct
     syntax keyword cppSTLtype piecewise_construct_t


### PR DESCRIPTION
All type_traits with ``type`` member as return
have type_trait_t alias to make the use simpler
without 'typename' keyword.
The highlighting is the same as for STL types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/octol/vim-cpp-enhanced-highlight/33)
<!-- Reviewable:end -->
