### PR TITLE
Added more C++14, C++17 and library concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 vim.cpp - additional vim c++ syntax highlighting
 ------------------------------------------------
 
-This file contains additional syntax highlighting that I use for C++11/14
+This file contains additional syntax highlighting that I use for C++11/14/17
 development in Vim. Compared to the standard syntax highlighting for C++ it
 adds highlighting of (user defined) functions and the containers and types in
 the standard library / boost.
@@ -25,12 +25,19 @@ let g:cpp_experimental_template_highlight = 1
 _Note: C++ template syntax is notoriously difficult to parse, so don't expect
 this feature to be perfect._
 
+Highlighting of library concepts is enabled by
+```vim
+let g:cpp_concepts_highlight = 1
+```
+This will highlight the keywords `concept` and `requires` as well as all named
+requirements (like `DefaultConstructible`) in the standard library.
+
 Installation instructions
 -------------------------
 Follow one of the sets of directions below and reload vim afterwards.
 
 #### Vundle
-Instal using [vundle](https://github.com/gmarik/Vundle.vim) by adding
+Install using [vundle](https://github.com/gmarik/Vundle.vim) by adding
 ```vim
 Plugin 'octol/vim-cpp-enhanced-highlight'
 ```
@@ -75,4 +82,4 @@ Background information
 
 Jon Haggblad <jon@haeggblad.com>
 
-Last update: 21 September 2014
+Last update: 12 October 2016

--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -2,16 +2,17 @@
 " Language: C++ Additions
 " Maintainer: Jon Haggblad <jon@haeggblad.com>
 " URL: http://www.haeggblad.com
-" Last Change: 21 Sep 2014
-" Version: 0.5
+" Last Change: 12 Oct 2016
+" Version: 0.6
 " Changelog:
 "   0.1 - initial version.
 "   0.2 - C++14
 "   0.3 - Incorporate lastest changes from Mizuchi/STL-Syntax
 "   0.4 - Add template function highlight
 "   0.5 - Redo template function highlight to be more robust. Add options.
+"   0.6 - more C++14, C++17, library concepts
 "
-" Additional Vim syntax highlighting for C++ (including C++11/14)
+" Additional Vim syntax highlighting for C++ (including C++11/14/17)
 "
 " This file contains additional syntax highlighting that I use for C++11/14
 " development in Vim. Compared to the standard syntax highlighting for C++ it
@@ -19,17 +20,17 @@
 " in the standard library / boost.
 "
 " Based on:
-"   http://stackoverflow.com/questions/736701/class-function-names-highlighting-in-vim
+"   http://stackoverflow.com/q/736701
 "   http://www.vim.org/scripts/script.php?script_id=4293
 "   http://www.vim.org/scripts/script.php?script_id=2224
 "   http://www.vim.org/scripts/script.php?script_id=1640
 "   http://www.vim.org/scripts/script.php?script_id=3064
 
+
 " -----------------------------------------------------------------------------
 "  Highlight Class and Function names.
 "
-" Based on the discussion in:
-"   http://stackoverflow.com/questions/736701/class-function-names-highlighting-in-vim
+" Based on the discussion in: http://stackoverflow.com/q/736701
 " -----------------------------------------------------------------------------
 
 " Functions
@@ -39,51 +40,51 @@ hi def link cCustomFunc  Function
 
 " Class and namespace scope
 if exists('g:cpp_class_scope_highlight') && g:cpp_class_scope_highlight
-    syn match    cCustomScope    "::"
-    syn match    cCustomClass    "\w\+\s*::" 
-                \contains=cCustomScope 
+    syn match   cCustomScope    "::"
+    syn match   cCustomClass    "\w\+\s*::"
+                \ contains=cCustomScope
     " hi def link cCustomClass Function  " disabled for now
-    syn match   cCustomClass    "\<\u\w*\s*\>" 
+    syn match   cCustomClass    "\<\u\w*\s*\>"
 endif
 
 " Template functions
 if exists('g:cpp_experimental_template_highlight') && g:cpp_experimental_template_highlight
 
-    syn match   cCustomAngleBracketStart "<\_[^;()]\{-}>" contained 
-                \contains=cCustomAngleBracketStart, cCustomAngleBracketEnd
+    syn match   cCustomAngleBracketStart "<\_[^;()]\{-}>" contained
+                \ contains=cCustomAngleBracketStart,cCustomAngleBracketEnd
     hi def link cCustomAngleBracketStart  cCustomAngleBracketContent
 
-    syn match   cCustomAngleBracketEnd ">\_[^<>;()]\{-}>" contained 
-                \contains=cCustomAngleBracketEnd
+    syn match   cCustomAngleBracketEnd ">\_[^<>;()]\{-}>" contained
+                \ contains=cCustomAngleBracketEnd
     hi def link cCustomAngleBracketEnd  cCustomAngleBracketContent
 
-    syn match cCustomTemplateFunc "\<\l\w*\s*<\_[^;()]\{-}>(\@="hs=s,he=e-1 
-                \contains=cCustomAngleBracketStart
+    syn match cCustomTemplateFunc "\<\l\w*\s*<\_[^;()]\{-}>(\@="hs=s,he=e-1
+                \ contains=cCustomAngleBracketStart
     hi def link cCustomTemplateFunc  cCustomFunc
 
-    syn match    cCustomTemplateClass    "\<\w\+\s*<\_[^;()]\{-}>" 
-                \contains=cCustomAngleBracketStart,cCustomTemplateFunc 
+    syn match    cCustomTemplateClass    "\<\w\+\s*<\_[^;()]\{-}>"
+                \ contains=cCustomAngleBracketStart,cCustomTemplateFunc
     hi def link cCustomTemplateClass cCustomClass
 
 
     " Remove 'template' from cppStructure and use a custom match
-    syn clear cppStructure 
+    syn clear cppStructure
     syn keyword cppStructure class typename namespace
 
-    syn match   cCustomTemplate "\<template\>" 
+    syn match   cCustomTemplate "\<template\>"
     hi def link cCustomTemplate  cppStructure
-    syn match   cTemplateDeclare "\<template\_s*<\_[^;()]\{-}>" 
-                \contains=cppStructure,cCustomTemplate,cCustomAngleBracketStart 
+    syn match   cTemplateDeclare "\<template\_s*<\_[^;()]\{-}>"
+                \ contains=cppStructure,cCustomTemplate,cCustomAngleBracketStart
 
     " Remove 'operator' from cppStructure and use a custom match
-    syn clear cppOperator 
+    syn clear cppOperator
     syn keyword cppOperator typeid
     syn keyword cppOperator and bitor or xor compl bitand and_eq or_eq xor_eq not not_eq
 
-    syn match   cCustomOperator "\<operator\>" 
+    syn match   cCustomOperator "\<operator\>"
     hi def link cCustomOperator  cppStructure
-    syn match   cTemplateOperatorDeclare "\<operator\_s*<\_[^;()]\{-}>[<>]=\?" 
-                \contains=cppOperator,cCustomOperator,cCustomAngleBracketStart 
+    syn match   cTemplateOperatorDeclare "\<operator\_s*<\_[^;()]\{-}>[<>]=\?"
+                \ contains=cppOperator,cCustomOperator,cCustomAngleBracketStart
 endif
 
 " Alternative syntax that is used in:
@@ -94,16 +95,18 @@ endif
 " Cluster for all the stdlib functions defined below
 syn cluster cppSTLgroup     contains=cppSTLfunction,cppSTLfunctional,cppSTLconstant,cppSTLnamespace,cppSTLtype,cppSTLexception,cppSTLiterator,cppSTLiterator_tagcppSTLenumcppSTLioscppSTLcast
 
+
 " -----------------------------------------------------------------------------
 "  Standard library types and functions.
 "
-" Mainly based on the excellent STL Syntax vim script by 
+" Mainly based on the excellent STL Syntax vim script by
 " Mizuchi <ytj000@gmail.com>
 "   http://www.vim.org/scripts/script.php?script_id=4293
 " which in turn is based on the scripts
 "   http://www.vim.org/scripts/script.php?script_id=2224
 "   http://www.vim.org/scripts/script.php?script_id=1640
 " -----------------------------------------------------------------------------
+
 syntax keyword cppSTLconstant badbit
 syntax keyword cppSTLconstant cerr
 syntax keyword cppSTLconstant cin
@@ -595,6 +598,7 @@ syntax keyword cppSTLiterator_tag output_iterator_tag
 syntax keyword cppSTLiterator_tag random_access_iterator_tag
 syntax keyword cppSTLnamespace rel_ops
 syntax keyword cppSTLnamespace std
+syntax keyword cppSTLnamespace experimental
 syntax keyword cppSTLtype allocator
 syntax keyword cppSTLtype auto_ptr
 syntax keyword cppSTLtype basic_filebuf
@@ -792,10 +796,519 @@ syntax keyword cppSTLconstant WEOF
 syntax keyword cppSTLconstant WCHAR_MIN
 syntax keyword cppSTLconstant WCHAR_MAX
 
+
 if !exists("cpp_no_cpp11")
-    syntax keyword cppSTLtype nullptr_t max_align_t
-    syntax keyword cppSTLtype type_index
     syntax keyword cppSTLconstant nullptr
+
+    " containers (array, vector, list, *map, *set, ...)
+    syntax keyword cppSTLtype array
+    syntax keyword cppSTLfunction cbegin cend
+    syntax keyword cppSTLfunction crbegin crend
+    syntax keyword cppSTLfunction shrink_to_fit
+    syntax keyword cppSTLfunction emplace
+    syntax keyword cppSTLfunction emplace_back
+    syntax keyword cppSTLfunction emplace_front
+    syntax keyword cppSTLfunction emplace_hint
+
+    " algorithm
+    syntax keyword cppSTLfunction all_of any_of none_of
+    syntax keyword cppSTLfunction find_if_not
+    syntax keyword cppSTLfunction copy_if
+    syntax keyword cppSTLfunction copy_n
+    syntax keyword cppSTLfunction move
+    syntax keyword cppSTLfunction move_backward
+    syntax keyword cppSTLfunction shuffle
+    syntax keyword cppSTLfunction is_partitioned
+    syntax keyword cppSTLfunction partition_copy
+    syntax keyword cppSTLfunction partition_point
+    syntax keyword cppSTLfunction is_sorted
+    syntax keyword cppSTLfunction is_sorted_until
+    syntax keyword cppSTLfunction is_heap
+    syntax keyword cppSTLfunction is_heap_until
+    syntax keyword cppSTLfunction minmax
+    syntax keyword cppSTLfunction minmax_element
+    syntax keyword cppSTLfunction is_permutation
+    syntax keyword cppSTLfunction itoa
+
+    " atomic
+    syntax keyword cppSTLtype atomic
+    syntax keyword cppSTLtype atomic_flag
+    syntax keyword cppSTLtype atomic_bool
+    syntax keyword cppSTLtype atomic_char
+    syntax keyword cppSTLtype atomic_schar
+    syntax keyword cppSTLtype atomic_uchar
+    syntax keyword cppSTLtype atomic_short
+    syntax keyword cppSTLtype atomic_ushort
+    syntax keyword cppSTLtype atomic_int
+    syntax keyword cppSTLtype atomic_uint
+    syntax keyword cppSTLtype atomic_long
+    syntax keyword cppSTLtype atomic_ulong
+    syntax keyword cppSTLtype atomic_llong
+    syntax keyword cppSTLtype atomic_ullong
+    syntax keyword cppSTLtype atomic_char16_t
+    syntax keyword cppSTLtype atomic_char32_t
+    syntax keyword cppSTLtype atomic_wchar_t
+    syntax keyword cppSTLtype atomic_int_least8_t
+    syntax keyword cppSTLtype atomic_uint_least8_t
+    syntax keyword cppSTLtype atomic_int_least16_t
+    syntax keyword cppSTLtype atomic_uint_least16_t
+    syntax keyword cppSTLtype atomic_int_least32_t
+    syntax keyword cppSTLtype atomic_uint_least32_t
+    syntax keyword cppSTLtype atomic_int_least64_t
+    syntax keyword cppSTLtype atomic_uint_least64_t
+    syntax keyword cppSTLtype atomic_int_fast8_t
+    syntax keyword cppSTLtype atomic_uint_fast8_t
+    syntax keyword cppSTLtype atomic_int_fast16_t
+    syntax keyword cppSTLtype atomic_uint_fast16_t
+    syntax keyword cppSTLtype atomic_int_fast32_t
+    syntax keyword cppSTLtype atomic_uint_fast32_t
+    syntax keyword cppSTLtype atomic_int_fast64_t
+    syntax keyword cppSTLtype atomic_uint_fast64_t
+    syntax keyword cppSTLtype atomic_intptr_t
+    syntax keyword cppSTLtype atomic_uintptr_t
+    syntax keyword cppSTLtype atomic_size_t
+    syntax keyword cppSTLtype atomic_ptrdiff_t
+    syntax keyword cppSTLtype atomic_intmax_t
+    syntax keyword cppSTLtype atomic_uintmax_t
+    syntax keyword cppSTLconstant ATOMIC_FLAG_INIT
+    syntax keyword cppSTLenum memory_order
+    syntax keyword cppSTLfunction is_lock_free
+    syntax keyword cppSTLfunction compare_exchange_weak
+    syntax keyword cppSTLfunction compare_exchange_strong
+    syntax keyword cppSTLfunction fetch_add
+    syntax keyword cppSTLfunction fetch_sub
+    syntax keyword cppSTLfunction fetch_and
+    syntax keyword cppSTLfunction fetch_or
+    syntax keyword cppSTLfunction fetch_xor
+    syntax keyword cppSTLfunction atomic_is_lock_free
+    syntax keyword cppSTLfunction atomic_store
+    syntax keyword cppSTLfunction atomic_store_explicit
+    syntax keyword cppSTLfunction atomic_load
+    syntax keyword cppSTLfunction atomic_load_explicit
+    syntax keyword cppSTLfunction atomic_exchange
+    syntax keyword cppSTLfunction atomic_exchange_explicit
+    syntax keyword cppSTLfunction atomic_compare_exchange_weak
+    syntax keyword cppSTLfunction atomic_compare_exchange_weak_explicit
+    syntax keyword cppSTLfunction atomic_compare_exchange_strong
+    syntax keyword cppSTLfunction atomic_compare_exchange_strong_explicit
+    syntax keyword cppSTLfunction atomic_fetch_add
+    syntax keyword cppSTLfunction atomic_fetch_add_explicit
+    syntax keyword cppSTLfunction atomic_fetch_sub
+    syntax keyword cppSTLfunction atomic_fetch_sub_explicit
+    syntax keyword cppSTLfunction atomic_fetch_and
+    syntax keyword cppSTLfunction atomic_fetch_and_explicit
+    syntax keyword cppSTLfunction atomic_fetch_or
+    syntax keyword cppSTLfunction atomic_fetch_or_explicit
+    syntax keyword cppSTLfunction atomic_fetch_xor
+    syntax keyword cppSTLfunction atomic_fetch_xor_explicit
+    syntax keyword cppSTLfunction atomic_flag_test_and_set
+    syntax keyword cppSTLfunction atomic_flag_test_and_set_explicit
+    syntax keyword cppSTLfunction atomic_flag_clear
+    syntax keyword cppSTLfunction atomic_flag_clear_explicit
+    syntax keyword cppSTLfunction atomic_init
+    syntax keyword cppSTLfunction ATOMIC_VAR_INIT
+    syntax keyword cppSTLfunction kill_dependency
+    syntax keyword cppSTLfunction atomic_thread_fence
+    syntax keyword cppSTLfunction atomic_signal_fence
+    syntax keyword cppSTLfunction exchange
+    " syntax keyword cppSTLfunction store
+    " syntax keyword cppSTLfunction load
+
+    " bitset
+    syntax keyword cppSTLfunction to_ullong
+    " syntax keyword cppSTLfunction all
+
+    " cinttypes
+    syntax keyword cppSTLfunction strtoimax
+    syntax keyword cppSTLfunction strtoumax
+    syntax keyword cppSTLfunction wcstoimax
+    syntax keyword cppSTLfunction wcstoumax
+
+    " chrono
+    syntax keyword cppSTLnamespace chrono
+    syntax keyword cppSTLcast duration_cast
+    syntax keyword cppSTLcast time_point_cast
+    syntax keyword cppSTLtype duration
+    syntax keyword cppSTLtype system_clock
+    syntax keyword cppSTLtype steady_clock
+    syntax keyword cppSTLtype high_resolution_clock
+    syntax keyword cppSTLtype time_point
+    syntax keyword cppSTLtype nanoseconds
+    syntax keyword cppSTLtype microseconds
+    syntax keyword cppSTLtype milliseconds
+    syntax keyword cppSTLtype seconds
+    syntax keyword cppSTLtype minutes
+    syntax keyword cppSTLtype hours
+    syntax keyword cppSTLtype treat_as_floating_point
+    syntax keyword cppSTLtype duration_values
+    " syntax keyword cppSTLtype rep period
+    syntax keyword cppSTLfunction time_since_epoch
+    syntax keyword cppSTLfunction to_time_t
+    syntax keyword cppSTLfunction from_time_t
+    " syntax keyword cppSTLfunction zero
+    " syntax keyword cppSTLfunction now
+
+    " complex
+    " syntax keyword cppSTLfunction proj
+
+    " condition_variable
+    syntax keyword cppSTLtype condition_variable
+    syntax keyword cppSTLfunction notify_all
+    syntax keyword cppSTLfunction notify_one
+
+    " cstddef
+    syntax keyword cppSTLtype nullptr_t max_align_t
+
+    " cstdlib
+    syntax keyword cppSTLfunction quick_exit
+    syntax keyword cppSTLfunction _Exit
+    syntax keyword cppSTLfunction at_quick_exit
+
+    " cuchar
+    syntax keyword cppSTLfunction mbrtoc16
+    syntax keyword cppSTLfunction c16rtomb
+    syntax keyword cppSTLfunction mbrtoc32
+    syntax keyword cppSTLfunction c32rtomb
+
+    " exception
+    syntax keyword cppSTLtype exception_ptr
+    syntax keyword cppSTLtype nested_exception
+    syntax keyword cppSTLfunction get_terminate
+    syntax keyword cppSTLfunction make_exception_ptr
+    syntax keyword cppSTLfunction current_exception
+    syntax keyword cppSTLfunction rethrow_exception
+    syntax keyword cppSTLfunction throw_with_nested
+    syntax keyword cppSTLfunction rethrow_if_nested
+    syntax keyword cppSTLfunction rethrow_nested
+
+    " forward_list
+    syntax keyword cppSTLtype forward_list
+    syntax keyword cppSTLfunction before_begin
+    syntax keyword cppSTLfunction cbefore_begin
+    syntax keyword cppSTLfunction insert_after
+    syntax keyword cppSTLfunction emplace_after
+    syntax keyword cppSTLfunction erase_after
+    syntax keyword cppSTLfunction splice_after
+
+    " functional
+    syntax keyword cppSTLexception bad_function_call
+    syntax keyword cppSTLfunctional function
+    syntax keyword cppSTLconstant _1 _2 _3 _4 _5 _6 _7 _8 _9
+    syntax keyword cppSTLtype hash
+    syntax keyword cppSTLtype is_bind_expression
+    syntax keyword cppSTLtype is_placeholder
+    syntax keyword cppSTLtype reference_wrapper
+    syntax keyword cppSTLfunction bind
+    syntax keyword cppSTLfunction mem_fn
+    syntax keyword cppSTLfunction ref cref
+
+    " future
+    syntax keyword cppSTLtype future
+    syntax keyword cppSTLtype packaged_task
+    syntax keyword cppSTLtype promise
+    syntax keyword cppSTLtype shared_future
+    syntax keyword cppSTLenum future_status
+    syntax keyword cppSTLenum future_errc
+    syntax keyword cppSTLenum launch
+    syntax keyword cppSTLexception future_error
+    syntax keyword cppSTLfunction get_future
+    syntax keyword cppSTLfunction set_value
+    syntax keyword cppSTLfunction set_value_at_thread_exit
+    syntax keyword cppSTLfunction set_exception
+    syntax keyword cppSTLfunction set_exception_at_thread_exit
+    syntax keyword cppSTLfunction wait_for
+    syntax keyword cppSTLfunction wait_until
+    syntax keyword cppSTLfunction future_category
+    syntax keyword cppSTLfunction make_error_code
+    syntax keyword cppSTLfunction make_error_condition
+    syntax keyword cppSTLfunction make_ready_at_thread_exit
+    " syntax keyword cppSTLfunction async
+    " syntax keyword cppSTLfunction share
+    " syntax keyword cppSTLfunction valid
+    " syntax keyword cppSTLfunction wait
+
+    " initializer_list
+    syntax keyword cppSTLtype initializer_list
+
+    " io
+    syntax keyword cppSTLenum io_errc
+    syntax keyword cppSTLfunction iostream_category
+    syntax keyword cppSTLfunction vscanf vfscanf vsscanf
+    syntax keyword cppSTLfunction snprintf vsnprintf
+    syntax keyword cppSTLfunction vwscanf vfwscanf vswscanf
+
+    " iterator
+    syntax keyword cppSTLiterator move_iterator
+    syntax keyword cppSTLfunction make_move_iterator
+    syntax keyword cppSTLfunction next prev
+
+    " limits
+    syntax keyword cppSTLconstant max_digits10
+    syntax keyword cppSTLfunction lowest
+
+    " locale
+    syntax keyword cppSTLtype wstring_convert
+    syntax keyword cppSTLtype wbuffer_convert
+    syntax keyword cppSTLtype codecvt_utf8
+    syntax keyword cppSTLtype codecvt_utf16
+    syntax keyword cppSTLtype codecvt_utf8_utf16
+    syntax keyword cppSTLtype codecvt_mode
+    syntax keyword cppSTLfunction isblank
+    syntax keyword cppSTLfunction iswblank
+
+    " memory
+    syntax keyword cppSTLtype unique_ptr
+    syntax keyword cppSTLtype shared_ptr
+    syntax keyword cppSTLtype weak_ptr
+    syntax keyword cppSTLtype owner_less
+    syntax keyword cppSTLtype enable_shared_from_this
+    syntax keyword cppSTLtype default_delete
+    syntax keyword cppSTLtype allocator_traits
+    syntax keyword cppSTLtype allocator_type
+    syntax keyword cppSTLtype allocator_arg_t
+    syntax keyword cppSTLtype uses_allocator
+    syntax keyword cppSTLtype scoped_allocator_adaptor
+    syntax keyword cppSTLtype pointer_safety
+    syntax keyword cppSTLtype pointer_traits
+    syntax keyword cppSTLconstant allocator_arg
+    syntax keyword cppSTLexception bad_weak_ptr
+    syntax keyword cppSTLcast static_pointer_cast
+    syntax keyword cppSTLcast dynamic_pointer_cast
+    syntax keyword cppSTLcast const_pointer_cast
+    syntax keyword cppSTLfunction make_shared
+    syntax keyword cppSTLfunction declare_reachable
+    syntax keyword cppSTLfunction undeclare_reachable
+    syntax keyword cppSTLfunction declare_no_pointers
+    syntax keyword cppSTLfunction undeclare_no_pointers
+    syntax keyword cppSTLfunction get_pointer_safety
+    syntax keyword cppSTLfunction addressof
+    syntax keyword cppSTLfunction allocate_shared
+    syntax keyword cppSTLfunction get_deleter
+    " syntax keyword cppSTLfunction align
+
+    " mutex
+    syntax keyword cppSTLtype mutex
+    syntax keyword cppSTLtype timed_mutex
+    syntax keyword cppSTLtype recursive_mutex
+    syntax keyword cppSTLtype recursive_timed_mutex
+    syntax keyword cppSTLtype lock_guard
+    syntax keyword cppSTLtype unique_lock
+    syntax keyword cppSTLtype defer_lock_t
+    syntax keyword cppSTLtype try_to_lock_t
+    syntax keyword cppSTLtype adopt_lock_t
+    syntax keyword cppSTLtype once_flag
+    syntax keyword cppSTLtype condition_variable_any
+    syntax keyword cppSTLenum cv_status
+    syntax keyword cppSTLconstant defer_lock try_to_lock adopt_lock
+    syntax keyword cppSTLfunction try_lock lock unlock try_lock_for try_lock_until
+    syntax keyword cppSTLfunction call_once
+    syntax keyword cppSTLfunction owns_lock
+    syntax keyword cppSTLfunction notify_all_at_thread_exit
+    syntax keyword cppSTLfunction release
+    " Note: unique_lock has method 'mutex()', but already set as cppSTLtype
+    " syntax keyword cppSTLfunction mutex
+
+    " new
+    syntax keyword cppSTLexception bad_array_new_length
+    syntax keyword cppSTLfunction get_new_handler
+
+    " numerics, cmath
+    syntax keyword cppSTLconstant HUGE_VALF
+    syntax keyword cppSTLconstant HUGE_VALL
+    syntax keyword cppSTLconstant INFINITY
+    syntax keyword cppSTLconstant NAN
+    syntax keyword cppSTLconstant math_errhandling
+    syntax keyword cppSTLconstant MATH_ERRNO
+    syntax keyword cppSTLconstant MATH_ERREXCEPT
+    syntax keyword cppSTLconstant FP_NORMAL
+    syntax keyword cppSTLconstant FP_SUBNORMAL
+    syntax keyword cppSTLconstant FP_ZERO
+    syntax keyword cppSTLconstant FP_INFINITY
+    syntax keyword cppSTLconstant FP_NAN
+    syntax keyword cppSTLconstant FLT_EVAL_METHOD
+    syntax keyword cppSTLfunction imaxabs
+    syntax keyword cppSTLfunction imaxdiv
+    syntax keyword cppSTLfunction remainder
+    syntax keyword cppSTLfunction remquo
+    syntax keyword cppSTLfunction fma
+    syntax keyword cppSTLfunction fmax
+    syntax keyword cppSTLfunction fmin
+    syntax keyword cppSTLfunction fdim
+    syntax keyword cppSTLfunction nan
+    syntax keyword cppSTLfunction nanf
+    syntax keyword cppSTLfunction nanl
+    syntax keyword cppSTLfunction exp2
+    syntax keyword cppSTLfunction expm1
+    syntax keyword cppSTLfunction log1p
+    syntax keyword cppSTLfunction log2
+    syntax keyword cppSTLfunction cbrt
+    syntax keyword cppSTLfunction hypot
+    syntax keyword cppSTLfunction asinh
+    syntax keyword cppSTLfunction acosh
+    syntax keyword cppSTLfunction atanh
+    syntax keyword cppSTLfunction erf
+    syntax keyword cppSTLfunction erfc
+    syntax keyword cppSTLfunction lgamma
+    syntax keyword cppSTLfunction tgamma
+    syntax keyword cppSTLfunction trunc
+    syntax keyword cppSTLfunction round
+    syntax keyword cppSTLfunction lround
+    syntax keyword cppSTLfunction llround
+    syntax keyword cppSTLfunction nearbyint
+    syntax keyword cppSTLfunction rint
+    syntax keyword cppSTLfunction lrint
+    syntax keyword cppSTLfunction llrint
+    syntax keyword cppSTLfunction scalbn
+    syntax keyword cppSTLfunction scalbln
+    syntax keyword cppSTLfunction ilogb
+    syntax keyword cppSTLfunction logb
+    syntax keyword cppSTLfunction nextafter
+    syntax keyword cppSTLfunction nexttoward
+    syntax keyword cppSTLfunction copysign
+    syntax keyword cppSTLfunction fpclassify
+    syntax keyword cppSTLfunction isfinite
+    syntax keyword cppSTLfunction isinf
+    syntax keyword cppSTLfunction isnan
+    syntax keyword cppSTLfunction isnormal
+    syntax keyword cppSTLfunction signbit
+
+    " random
+    syntax keyword cppSTLtype linear_congruential_engine
+    syntax keyword cppSTLtype mersenne_twister_engine
+    syntax keyword cppSTLtype subtract_with_carry_engine
+    syntax keyword cppSTLtype discard_block_engine
+    syntax keyword cppSTLtype independent_bits_engine
+    syntax keyword cppSTLtype shuffle_order_engine
+    syntax keyword cppSTLtype random_device
+    syntax keyword cppSTLtype default_random_engine
+    syntax keyword cppSTLtype minstd_rand0
+    syntax keyword cppSTLtype minstd_rand
+    syntax keyword cppSTLtype mt19937
+    syntax keyword cppSTLtype mt19937_64
+    syntax keyword cppSTLtype ranlux24_base
+    syntax keyword cppSTLtype ranlux48_base
+    syntax keyword cppSTLtype ranlux24
+    syntax keyword cppSTLtype ranlux48
+    syntax keyword cppSTLtype knuth_b
+    syntax keyword cppSTLtype uniform_int_distribution
+    syntax keyword cppSTLtype uniform_real_distribution
+    syntax keyword cppSTLtype bernoulli_distribution
+    syntax keyword cppSTLtype binomial_distribution
+    syntax keyword cppSTLtype negative_binomial_distribution
+    syntax keyword cppSTLtype geometric_distribution
+    syntax keyword cppSTLtype poisson_distribution
+    syntax keyword cppSTLtype exponential_distribution
+    syntax keyword cppSTLtype gamma_distribution
+    syntax keyword cppSTLtype weibull_distribution
+    syntax keyword cppSTLtype extreme_value_distribution
+    syntax keyword cppSTLtype normal_distribution
+    syntax keyword cppSTLtype lognormal_distribution
+    syntax keyword cppSTLtype chi_squared_distribution
+    syntax keyword cppSTLtype cauchy_distribution
+    syntax keyword cppSTLtype fisher_f_distribution
+    syntax keyword cppSTLtype student_t_distribution
+    syntax keyword cppSTLtype discrete_distribution
+    syntax keyword cppSTLtype piecewise_constant_distribution
+    syntax keyword cppSTLtype piecewise_linear_distribution
+    syntax keyword cppSTLtype seed_seq
+    syntax keyword cppSTLfunction generate_canonical
+
+    " ratio
+    syntax keyword cppSTLtype ratio
+    syntax keyword cppSTLtype yocto
+    syntax keyword cppSTLtype zepto
+    syntax keyword cppSTLtype atto
+    syntax keyword cppSTLtype femto
+    syntax keyword cppSTLtype pico
+    syntax keyword cppSTLtype nano
+    syntax keyword cppSTLtype micro
+    syntax keyword cppSTLtype milli
+    syntax keyword cppSTLtype centi
+    syntax keyword cppSTLtype deci
+    syntax keyword cppSTLtype deca
+    syntax keyword cppSTLtype hecto
+    syntax keyword cppSTLtype kilo
+    syntax keyword cppSTLtype mega
+    syntax keyword cppSTLtype giga
+    syntax keyword cppSTLtype tera
+    syntax keyword cppSTLtype peta
+    syntax keyword cppSTLtype exa
+    syntax keyword cppSTLtype zetta
+    syntax keyword cppSTLtype yotta
+    syntax keyword cppSTLtype ratio_add
+    syntax keyword cppSTLtype ratio_subtract
+    syntax keyword cppSTLtype ratio_multiply
+    syntax keyword cppSTLtype ratio_divide
+    syntax keyword cppSTLtype ratio_equal
+    syntax keyword cppSTLtype ratio_not_equal
+    syntax keyword cppSTLtype ratio_less
+    syntax keyword cppSTLtype ratio_less_equal
+    syntax keyword cppSTLtype ratio_greater
+    syntax keyword cppSTLtype ratio_greater_equal
+
+    " regex
+    syntax keyword cppSTLtype basic_regex
+    syntax keyword cppSTLtype sub_match
+    syntax keyword cppSTLtype match_results
+    syntax keyword cppSTLtype regex_traits
+    syntax keyword cppSTLtype regex_match regex_search regex_replace
+    syntax keyword cppSTLiterator regex_iterator
+    syntax keyword cppSTLiterator regex_token_iterator
+    syntax keyword cppSTLexception regex_error
+    syntax keyword cppSTLtype syntax_option_type match_flag_type error_type
+
+    " string
+    syntax keyword cppSTLfunction stoi
+    syntax keyword cppSTLfunction stol
+    syntax keyword cppSTLfunction stoll
+    syntax keyword cppSTLfunction stoul
+    syntax keyword cppSTLfunction stoull
+    syntax keyword cppSTLfunction stof
+    syntax keyword cppSTLfunction stod
+    syntax keyword cppSTLfunction stold
+
+    " system_error
+    syntax keyword cppSTLenum errc
+    syntax keyword cppSTLtype system_error
+    syntax keyword cppSTLtype error_code
+    syntax keyword cppSTLtype error_condition
+    syntax keyword cppSTLtype error_category
+    syntax keyword cppSTLtype is_error_code_enum
+    syntax keyword cppSTLtype is_error_condition_enum
+    " syntax keyword cppSTLfunction default_error_condition
+    " syntax keyword cppSTLfunction generic_category
+    " syntax keyword cppSTLfunction system_category
+    " syntax keyword cppSTLfunction code
+    " syntax keyword cppSTLfunction category
+    " syntax keyword cppSTLfunction message
+    " syntax keyword cppSTLfunction equivalent
+
+    " thread
+    syntax keyword cppSTLnamespace this_thread
+    syntax keyword cppSTLtype thread
+    syntax keyword cppSTLfunction get_id
+    syntax keyword cppSTLfunction sleep_for
+    syntax keyword cppSTLfunction sleep_until
+    syntax keyword cppSTLfunction joinable
+    syntax keyword cppSTLfunction native_handle
+    syntax keyword cppSTLfunction hardware_concurrency
+    " syntax keyword cppSTLfunction yield
+    " syntax keyword cppSTLfunction join
+    " syntax keyword cppSTLfunction detach
+
+    " tuple
+    syntax keyword cppSTLtype tuple
+    syntax keyword cppSTLtype tuple_size
+    syntax keyword cppSTLtype tuple_element
+    syntax keyword cppSTLfunction make_tuple
+    syntax keyword cppSTLfunction tie
+    syntax keyword cppSTLfunction forward_as_tuple
+    syntax keyword cppSTLfunction tuple_cat
+    " Note: 'ignore' is already set as cppSTLfunction
+    " syntax keyword cppSTLconstant ignore
+
+    " typeindex
+    syntax keyword cppSTLtype type_index
 
     " type_traits
     syntax keyword cppSTLtype is_void
@@ -853,6 +1366,8 @@ if !exists("cpp_no_cpp11")
     syntax keyword cppSTLtype is_nothrow_move_assignable
     syntax keyword cppSTLtype is_destructible
     syntax keyword cppSTLtype is_trivially_destructible
+    syntax keyword cppSTLtype is_nothrow_destructible
+    syntax keyword cppSTLtype has_virtual_destructor
     syntax keyword cppSTLtype alignment_of
     syntax keyword cppSTLtype rank
     syntax keyword cppSTLtype extent
@@ -885,8 +1400,76 @@ if !exists("cpp_no_cpp11")
     syntax keyword cppSTLtype integral_constant
     syntax keyword cppSTLtype true_type
     syntax keyword cppSTLtype false_type
+
+    " unordered_map, unordered_set, unordered_multimap, unordered_multiset
+    syntax keyword cppSTLtype unordered_map
+    syntax keyword cppSTLtype unordered_set
+    syntax keyword cppSTLtype unordered_multimap
+    syntax keyword cppSTLtype unordered_multiset
+    syntax keyword cppSTLtype hasher
+    syntax keyword cppSTLtype key_equal
+    syntax keyword cppSTLiterator local_iterator
+    syntax keyword cppSTLiterator const_local_iterator
+    syntax keyword cppSTLfunction bucket_count
+    syntax keyword cppSTLfunction max_bucket_count
+    syntax keyword cppSTLfunction bucket_size
+    syntax keyword cppSTLfunction bucket
+    syntax keyword cppSTLfunction load_factor
+    syntax keyword cppSTLfunction max_load_factor
+    syntax keyword cppSTLfunction rehash
+    syntax keyword cppSTLfunction reserve
+    syntax keyword cppSTLfunction hash_function
+    syntax keyword cppSTLfunction key_eq
+
+    " utility
+    syntax keyword cppSTLtype piecewise_construct_t
+    syntax keyword cppSTLconstant piecewise_construct
     syntax keyword cppSTLfunction declval
-    " C++14 helper aliases for type traits.
+    syntax keyword cppSTLfunction forward
+    syntax keyword cppSTLfunction move_if_noexcept
+
+    " raw string literals
+    syntax region cppRawString matchgroup=cppRawDelimiter start=@\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(@ end=/)\z1"/ contains=@Spell
+
+    syn match cNumber "0b[01]\+"
+endif " C++11
+
+
+if !exists("cpp_no_cpp14")
+    " chrono
+    syntax keyword cppSTLnamespace literals
+    syntax keyword cppSTLnamespace chrono_literals
+
+    " iterator
+    syntax keyword cppSTLfunction make_reverse_iterator
+
+    " memory
+    syntax keyword cppSTLfunction make_unique
+
+    " utility
+    syntax keyword cppSTLtype integer_sequence
+    syntax keyword cppSTLtype index_sequence
+    syntax keyword cppSTLtype make_integer_sequence
+    syntax keyword cppSTLtype make_index_sequence
+    syntax keyword cppSTLtype index_sequence_for
+
+    " shared_mutex
+    syntax keyword cppSTLtype shared_timed_mutex
+    syntax keyword cppSTLtype shared_lock
+    syntax keyword cppSTLfunction lock_shared
+    syntax keyword cppSTLfunction unlock_shared
+    syntax keyword cppSTLfunction try_lock_shared
+    syntax keyword cppSTLfunction try_lock_shared_for
+    syntax keyword cppSTLfunction try_lock_shared_until
+
+    " string
+    syntax keyword cppSTLnamespace string_literals
+
+    " tuple
+    syntax keyword cppSTLtype tuple_element_t
+
+    " type_traits
+    syntax keyword cppSTLtype is_null_pointer
     syntax keyword cppSTLtype remove_cv_t
     syntax keyword cppSTLtype remove_const_t
     syntax keyword cppSTLtype remove_volatile_t
@@ -910,494 +1493,456 @@ if !exists("cpp_no_cpp11")
     syntax keyword cppSTLtype common_type_t
     syntax keyword cppSTLtype underlying_type_t
     syntax keyword cppSTLtype result_of_t
-
-    syntax keyword cppSTLconstant piecewise_construct
-    syntax keyword cppSTLtype piecewise_construct_t
-
-    " memory
-    syntax keyword cppSTLtype unique_ptr
-    syntax keyword cppSTLtype shared_ptr
-    syntax keyword cppSTLtype weak_ptr
-    syntax keyword cppSTLtype owner_less
-    syntax keyword cppSTLtype enable_shared_from_this
-    syntax keyword cppSTLexception bad_weak_ptr
-    syntax keyword cppSTLtype default_delete
-    syntax keyword cppSTLtype allocator_traits
-    syntax keyword cppSTLtype allocator_type
-    syntax keyword cppSTLtype allocator_arg_t
-    syntax keyword cppSTLconstant allocator_arg
-    syntax keyword cppSTLtype uses_allocator
-    syntax keyword cppSTLtype scoped_allocator_adaptor
-    syntax keyword cppSTLfunction declare_reachable
-    syntax keyword cppSTLfunction undeclare_reachable
-    syntax keyword cppSTLfunction declare_no_pointers
-    syntax keyword cppSTLfunction undeclare_no_pointers
-    syntax keyword cppSTLfunction get_pointer_safety
-    syntax keyword cppSTLtype pointer_safety
-    syntax keyword cppSTLtype pointer_traits
-    syntax keyword cppSTLfunction addressof
-    syntax keyword cppSTLfunction align
-    syntax keyword cppSTLfunction make_shared
-    syntax keyword cppSTLfunction allocate_shared
-    syntax keyword cppSTLcast static_pointer_cast
-    syntax keyword cppSTLcast dynamic_pointer_cast
-    syntax keyword cppSTLcast const_pointer_cast
-    syntax keyword cppSTLfunction get_deleter
-
-    " function object
-    syntax keyword cppSTLfunction bind
-    syntax keyword cppSTLtype is_bind_expression
-    syntax keyword cppSTLtype is_placeholder
-    syntax keyword cppSTLconstant _1 _2 _3 _4 _5 _6 _7 _8 _9
-    syntax keyword cppSTLfunction mem_fn
-    syntax keyword cppSTLfunctional function
-    syntax keyword cppSTLexception bad_function_call
-    syntax keyword cppSTLtype reference_wrapper
-    syntax keyword cppSTLfunction ref cref
-
-    " bitset
-    syntax keyword cppSTLfunction all
-    syntax keyword cppSTLfunction to_ullong
-
-    " iterator
-    syntax keyword cppSTLiterator move_iterator
-    syntax keyword cppSTLfunction make_move_iterator
-    syntax keyword cppSTLfunction next prev
-
-    " program support utilities
-    syntax keyword cppSTLfunction quick_exit
-    syntax keyword cppSTLfunction _Exit
-    syntax keyword cppSTLfunction at_quick_exit
-    syntax keyword cppSTLfunction forward
-
-    " date and time
-    syntax keyword cppSTLnamespace chrono
-    syntax keyword cppSTLtype duration
-    syntax keyword cppSTLtype system_clock
-    syntax keyword cppSTLtype steady_clock
-    syntax keyword cppSTLtype high_resolution_clock
-    syntax keyword cppSTLtype time_point
-    syntax keyword cppSTLcast duration_cast
-    syntax keyword cppSTLcast time_point_cast
-
-    " tuple
-    syntax keyword cppSTLtype tuple
-    syntax keyword cppSTLfunction make_tuple
-    syntax keyword cppSTLfunction tie
-    syntax keyword cppSTLfunction forward_as_tuple
-    syntax keyword cppSTLfunction tuple_cat
-    syntax keyword cppSTLtype tuple_size tuple_element
-
-    " Container
-    syntax keyword cppSTLtype array
-    syntax keyword cppSTLtype forward_list
-    syntax keyword cppSTLtype unordered_map
-    syntax keyword cppSTLtype unordered_set
-    syntax keyword cppSTLtype unordered_multimap
-    syntax keyword cppSTLtype unordered_multiset
-    syntax keyword cppSTLtype tuple
-    syntax keyword cppSTLfunction cbegin
-    syntax keyword cppSTLfunction cend
-    syntax keyword cppSTLfunction crbegin
-    syntax keyword cppSTLfunction crend
-    syntax keyword cppSTLfunction shrink_to_fit
-    syntax keyword cppSTLfunction emplace
-    syntax keyword cppSTLfunction emplace_back
-    syntax keyword cppSTLfunction emplace_front
-    syntax keyword cppSTLfunction emplace_hint
-
-    "forward_list
-    syntax keyword cppSTLfunction before_begin
-    syntax keyword cppSTLfunction cbefore_begin
-    syntax keyword cppSTLfunction insert_after
-    syntax keyword cppSTLfunction emplace_after
-    syntax keyword cppSTLfunction erase_after
-    syntax keyword cppSTLfunction splice_after
-
-    " unordered
-    syntax keyword cppSTLtype hash
-    syntax keyword cppSTLtype hasher
-    syntax keyword cppSTLtype key_equal
-    syntax keyword cppSTLiterator local_iterator
-    syntax keyword cppSTLiterator const_local_iterator
-    syntax keyword cppSTLfunction bucket_count
-    syntax keyword cppSTLfunction max_bucket_count
-    syntax keyword cppSTLfunction bucket_size
-    syntax keyword cppSTLfunction bucket
-    syntax keyword cppSTLfunction load_factor
-    syntax keyword cppSTLfunction max_load_factor
-    syntax keyword cppSTLfunction rehash
-    syntax keyword cppSTLfunction reserve
-    syntax keyword cppSTLfunction hash_function
-    syntax keyword cppSTLfunction key_eq
-
-    " algorithm
-    syntax keyword cppSTLfunction all_of any_of none_of
-    syntax keyword cppSTLfunction find_if_not
-    syntax keyword cppSTLfunction copy_if
-    syntax keyword cppSTLfunction copy_n
-    syntax keyword cppSTLfunction move
-    syntax keyword cppSTLfunction move_if_noexcept
-    syntax keyword cppSTLfunction move_backward
-    syntax keyword cppSTLfunction shuffle
-    syntax keyword cppSTLfunction is_partitioned
-    syntax keyword cppSTLfunction partition_copy
-    syntax keyword cppSTLfunction partition_point
-    syntax keyword cppSTLfunction is_sorted
-    syntax keyword cppSTLfunction is_sorted_until
-    syntax keyword cppSTLfunction is_heap_until
-    syntax keyword cppSTLfunction minmax
-    syntax keyword cppSTLfunction minmax_element
-    syntax keyword cppSTLfunction is_permutation
-    syntax keyword cppSTLfunction itoa
-
-    " numerics
-    syntax keyword cppSTLfunction imaxabs
-    syntax keyword cppSTLfunction imaxdiv
-    syntax keyword cppSTLfunction remainder
-    syntax keyword cppSTLfunction remquo
-    syntax keyword cppSTLfunction fma
-    syntax keyword cppSTLfunction fmax
-    syntax keyword cppSTLfunction fmin
-    syntax keyword cppSTLfunction fdim
-    syntax keyword cppSTLfunction nan
-    syntax keyword cppSTLfunction nanf
-    syntax keyword cppSTLfunction nanl
-    syntax keyword cppSTLfunction exp2
-    syntax keyword cppSTLfunction expm1
-    syntax keyword cppSTLfunction log1p
-    syntax keyword cppSTLfunction log2
-    syntax keyword cppSTLfunction cbrt
-    syntax keyword cppSTLfunction hypot
-    syntax keyword cppSTLfunction asinh
-    syntax keyword cppSTLfunction acosh
-    syntax keyword cppSTLfunction atanh
-    syntax keyword cppSTLfunction erf
-    syntax keyword cppSTLfunction erfc
-    syntax keyword cppSTLfunction lgamma
-    syntax keyword cppSTLfunction tgamma
-    syntax keyword cppSTLfunction trunc
-    syntax keyword cppSTLfunction round
-    syntax keyword cppSTLfunction lround
-    syntax keyword cppSTLfunction llround
-    syntax keyword cppSTLfunction nearbyint
-    syntax keyword cppSTLfunction rint
-    syntax keyword cppSTLfunction lrint
-    syntax keyword cppSTLfunction llrint
-    syntax keyword cppSTLfunction scalbn
-    syntax keyword cppSTLfunction scalbln
-    syntax keyword cppSTLfunction ilogb
-    syntax keyword cppSTLfunction logb
-    syntax keyword cppSTLfunction nextafter
-    syntax keyword cppSTLfunction nexttoward
-    syntax keyword cppSTLfunction copysign
-    syntax keyword cppSTLfunction fpclassify
-    syntax keyword cppSTLfunction isfinite
-    syntax keyword cppSTLfunction isinf
-    syntax keyword cppSTLfunction isnan
-    syntax keyword cppSTLfunction isnormal
-    syntax keyword cppSTLfunction signbit
-    syntax keyword cppSTLconstant HUGE_VALF
-    syntax keyword cppSTLconstant HUGE_VALL
-    syntax keyword cppSTLconstant INFINITY
-    syntax keyword cppSTLconstant NAN
-    syntax keyword cppSTLconstant math_errhandling
-    syntax keyword cppSTLconstant MATH_ERRNO
-    syntax keyword cppSTLconstant MATH_ERREXCEPT
-    syntax keyword cppSTLconstant FP_NORMAL
-    syntax keyword cppSTLconstant FP_SUBNORMAL
-    syntax keyword cppSTLconstant FP_ZERO
-    syntax keyword cppSTLconstant FP_INFINITY
-    syntax keyword cppSTLconstant FP_NAN
-    syntax keyword cppSTLconstant FLT_EVAL_METHOD
-
-    " complex
-    "syntax keyword cppSTLfunction proj
-
-    " random
-    syntax keyword cppSTLtype linear_congruential_engine
-    syntax keyword cppSTLtype mersenne_twister_engine
-    syntax keyword cppSTLtype subtract_with_carry_engine
-    syntax keyword cppSTLtype discard_block_engine
-    syntax keyword cppSTLtype independent_bits_engine
-    syntax keyword cppSTLtype shuffle_order_engine
-    syntax keyword cppSTLtype random_device
-    syntax keyword cppSTLtype default_random_engine
-    syntax keyword cppSTLtype minstd_rand0
-    syntax keyword cppSTLtype minstd_rand
-    syntax keyword cppSTLtype mt19937
-    syntax keyword cppSTLtype mt19937_64
-    syntax keyword cppSTLtype ranlux24_base
-    syntax keyword cppSTLtype ranlux48_base
-    syntax keyword cppSTLtype ranlux24
-    syntax keyword cppSTLtype ranlux48
-    syntax keyword cppSTLtype knuth_b
-    syntax keyword cppSTLfunction generate_canonical
-    syntax keyword cppSTLtype uniform_int_distribution
-    syntax keyword cppSTLtype uniform_real_distribution
-    syntax keyword cppSTLtype bernoulli_distribution
-    syntax keyword cppSTLtype binomial_distribution
-    syntax keyword cppSTLtype negative_binomial_distribution
-    syntax keyword cppSTLtype geometric_distribution
-    syntax keyword cppSTLtype poisson_distribution
-    syntax keyword cppSTLtype exponential_distribution
-    syntax keyword cppSTLtype gamma_distribution
-    syntax keyword cppSTLtype weibull_distribution
-    syntax keyword cppSTLtype extreme_value_distribution
-    syntax keyword cppSTLtype normal_distribution
-    syntax keyword cppSTLtype lognormal_distribution
-    syntax keyword cppSTLtype chi_squared_distribution
-    syntax keyword cppSTLtype cauchy_distribution
-    syntax keyword cppSTLtype fisher_f_distribution
-    syntax keyword cppSTLtype student_t_distribution
-    syntax keyword cppSTLtype discrete_distribution
-    syntax keyword cppSTLtype piecewise_constant_distribution
-    syntax keyword cppSTLtype piecewise_linear_distribution
-    syntax keyword cppSTLtype seed_seq
-
-    " io
-    syntax keyword cppSTLfunction iostream_category
-    syntax keyword cppSTLenum io_errc
-    syntax keyword cppSTLfunction vscanf vfscanf vsscanf
-    syntax keyword cppSTLfunction snprintf vsnprintf
-    syntax keyword cppSTLfunction vwscanf vfwscanf vswscanf
-
-    " locale
-    syntax keyword cppSTLfunction isblank
-    syntax keyword cppSTLfunction iswblank
-    syntax keyword cppSTLtype wstring_convert
-    syntax keyword cppSTLtype wbuffer_convert
-    syntax keyword cppSTLtype codecvt_utf8
-    syntax keyword cppSTLtype codecvt_utf16
-    syntax keyword cppSTLtype codecvt_utf8_utf16
-    syntax keyword cppSTLtype codecvt_mode
-
-    " regex
-    syntax keyword cppSTLtype basic_regex
-    syntax keyword cppSTLtype sub_match
-    syntax keyword cppSTLtype match_results
-    syntax keyword cppSTLtype regex_traits
-    syntax keyword cppSTLtype regex_match regex_search regex_replace
-    syntax keyword cppSTLiterator regex_iterator
-    syntax keyword cppSTLiterator regex_token_iterator
-    syntax keyword cppSTLexception regex_error
-    syntax keyword cppSTLtype syntax_option_type match_flag_type error_type
-
-    " atomic
-    syntax keyword cppSTLtype atomic
-    syntax keyword cppSTLfunction atomic_is_lock_free
-    syntax keyword cppSTLfunction atomic_store
-    syntax keyword cppSTLfunction atomic_store_explicit
-    syntax keyword cppSTLfunction atomic_load
-    syntax keyword cppSTLfunction atomic_load_explicit
-    syntax keyword cppSTLfunction atomic_exchange
-    syntax keyword cppSTLfunction atomic_exchange_explicit
-    syntax keyword cppSTLfunction atomic_compare_exchange_weak
-    syntax keyword cppSTLfunction atomic_compare_exchange_weak_explicit
-    syntax keyword cppSTLfunction atomic_compare_exchange_strong
-    syntax keyword cppSTLfunction atomic_compare_exchange_strong_explicit
-    syntax keyword cppSTLfunction atomic_fetch_add
-    syntax keyword cppSTLfunction atomic_fetch_add_explicit
-    syntax keyword cppSTLfunction atomic_fetch_sub
-    syntax keyword cppSTLfunction atomic_fetch_sub_explicit
-    syntax keyword cppSTLfunction atomic_fetch_and
-    syntax keyword cppSTLfunction atomic_fetch_and_explicit
-    syntax keyword cppSTLfunction atomic_fetch_or
-    syntax keyword cppSTLfunction atomic_fetch_or_explicit
-    syntax keyword cppSTLfunction atomic_fetch_xor
-    syntax keyword cppSTLfunction atomic_fetch_xor_explicit
-
-    syntax keyword cppSTLtype atomic_flag
-    syntax keyword cppSTLfunction atomic_flag_test_and_set
-    syntax keyword cppSTLfunction atomic_flag_test_and_set_explicit
-    syntax keyword cppSTLfunction atomic_flag_clear
-    syntax keyword cppSTLfunction atomic_flag_clear_explicit
-
-    syntax keyword cppSTLtype atomic_bool
-    syntax keyword cppSTLtype atomic_char
-    syntax keyword cppSTLtype atomic_schar
-    syntax keyword cppSTLtype atomic_uchar
-    syntax keyword cppSTLtype atomic_short
-    syntax keyword cppSTLtype atomic_ushort
-    syntax keyword cppSTLtype atomic_int
-    syntax keyword cppSTLtype atomic_uint
-    syntax keyword cppSTLtype atomic_long
-    syntax keyword cppSTLtype atomic_ulong
-    syntax keyword cppSTLtype atomic_llong
-    syntax keyword cppSTLtype atomic_ullong
-    syntax keyword cppSTLtype atomic_char16_t
-    syntax keyword cppSTLtype atomic_char32_t
-    syntax keyword cppSTLtype atomic_wchar_t
-    syntax keyword cppSTLtype atomic_int_least8_t
-    syntax keyword cppSTLtype atomic_uint_least8_t
-    syntax keyword cppSTLtype atomic_int_least16_t
-    syntax keyword cppSTLtype atomic_uint_least16_t
-    syntax keyword cppSTLtype atomic_int_least32_t
-    syntax keyword cppSTLtype atomic_uint_least32_t
-    syntax keyword cppSTLtype atomic_int_least64_t
-    syntax keyword cppSTLtype atomic_uint_least64_t
-    syntax keyword cppSTLtype atomic_int_fast8_t
-    syntax keyword cppSTLtype atomic_uint_fast8_t
-    syntax keyword cppSTLtype atomic_int_fast16_t
-    syntax keyword cppSTLtype atomic_uint_fast16_t
-    syntax keyword cppSTLtype atomic_int_fast32_t
-    syntax keyword cppSTLtype atomic_uint_fast32_t
-    syntax keyword cppSTLtype atomic_int_fast64_t
-    syntax keyword cppSTLtype atomic_uint_fast64_t
-    syntax keyword cppSTLtype atomic_intptr_t
-    syntax keyword cppSTLtype atomic_uintptr_t
-    syntax keyword cppSTLtype atomic_size_t
-    syntax keyword cppSTLtype atomic_ptrdiff_t
-    syntax keyword cppSTLtype atomic_intmax_t
-    syntax keyword cppSTLtype atomic_uintmax_t
-
-    syntax keyword cppSTLtype memory_order
-    syntax keyword cppSTLfunction atomic_init
-    syntax keyword cppSTLfunction ATOMIC_VAR_INIT
-    syntax keyword cppSTLconstant ATOMIC_FLAG_INIT
-    syntax keyword cppSTLfunction kill_dependency
-    syntax keyword cppSTLfunction atomic_thread_fence
-    syntax keyword cppSTLfunction atomic_signal_fence
-
-    " thread
-    syntax keyword cppSTLtype thread
-    syntax keyword cppSTLnamespace this_thread
-    syntax keyword cppSTLfunction yield
-    syntax keyword cppSTLfunction get_id
-    syntax keyword cppSTLfunction sleep_for
-    syntax keyword cppSTLfunction sleep_until
-
-    syntax keyword cppSTLfunction joinable
-    syntax keyword cppSTLfunction get_id
-    syntax keyword cppSTLfunction native_handle
-    syntax keyword cppSTLfunction hardware_concurrency
-    syntax keyword cppSTLfunction join
-    syntax keyword cppSTLfunction detach
-
-    syntax keyword cppSTLtype mutex
-    syntax keyword cppSTLtype timed_mutex
-    syntax keyword cppSTLtype recursive_mutex
-    syntax keyword cppSTLtype recursive_timed_mutex
-    syntax keyword cppSTLtype lock_guard
-    syntax keyword cppSTLtype unique_lock
-    syntax keyword cppSTLtype defer_lock_t
-    syntax keyword cppSTLtype try_to_lock_t
-    syntax keyword cppSTLtype adopt_lock_t
-    syntax keyword cppSTLconstant defer_lock try_to_lock adopt_lock
-    syntax keyword cppSTLfunction try_lock lock
-    syntax keyword cppSTLfunction call_once
-    syntax keyword cppSTLtype once_flag
-    syntax keyword cppSTLtype condition_variable
-    syntax keyword cppSTLtype condition_variable_any
-    syntax keyword cppSTLfunction notify_all_at_thread_exit
-    syntax keyword cppSTLenum cv_status
-
-    syntax keyword cppSTLtype promise
-    syntax keyword cppSTLtype packaged_task
-    syntax keyword cppSTLtype future
-    syntax keyword cppSTLtype shared_future
-
-    syntax keyword cppSTLfunction async
-    syntax keyword cppSTLenum launch
-
-    syntax keyword cppSTLenum future_status
-    syntax keyword cppSTLenum future_errc
-    syntax keyword cppSTLtype future_error
-    syntax keyword cppSTLfunction future_category
-
-    " string
-    syntax keyword cppSTLfunction stoi
-    syntax keyword cppSTLfunction stol
-    syntax keyword cppSTLfunction stoll
-    syntax keyword cppSTLfunction stoul
-    syntax keyword cppSTLfunction stoull
-    syntax keyword cppSTLfunction stof
-    syntax keyword cppSTLfunction stod
-    syntax keyword cppSTLfunction stold
-
-    " ratio
-    syntax keyword cppSTLtype ratio
-    syntax keyword cppSTLtype yocto
-    syntax keyword cppSTLtype zepto
-    syntax keyword cppSTLtype atto
-    syntax keyword cppSTLtype femto
-    syntax keyword cppSTLtype pico
-    syntax keyword cppSTLtype nano
-    syntax keyword cppSTLtype micro
-    syntax keyword cppSTLtype milli
-    syntax keyword cppSTLtype centi
-    syntax keyword cppSTLtype deci
-    syntax keyword cppSTLtype deca
-    syntax keyword cppSTLtype hecto
-    syntax keyword cppSTLtype kilo
-    syntax keyword cppSTLtype mega
-    syntax keyword cppSTLtype giga
-    syntax keyword cppSTLtype tera
-    syntax keyword cppSTLtype peta
-    syntax keyword cppSTLtype exa
-    syntax keyword cppSTLtype zetta
-    syntax keyword cppSTLtype yotta
-    syntax keyword cppSTLtype ratio_add
-    syntax keyword cppSTLtype ratio_subtract
-    syntax keyword cppSTLtype ratio_multiply
-    syntax keyword cppSTLtype ratio_divide
-    syntax keyword cppSTLtype ratio_equal
-    syntax keyword cppSTLtype ratio_not_equal
-    syntax keyword cppSTLtype ratio_less
-    syntax keyword cppSTLtype ratio_less_equal
-    syntax keyword cppSTLtype ratio_greater
-    syntax keyword cppSTLtype ratio_greater_equal
-
-    "limits
-    syntax keyword cppSTLfunction lowest
-
-    "cuchar
-    syntax keyword cppSTLfunction mbrtoc16
-    syntax keyword cppSTLfunction c16rtomb
-    syntax keyword cppSTLfunction mbrtoc32
-    syntax keyword cppSTLfunction c32rtomb
-
-    "cinttypes
-    syntax keyword cppSTLfunction strtoimax
-    syntax keyword cppSTLfunction strtoumax
-    syntax keyword cppSTLfunction wcstoimax
-    syntax keyword cppSTLfunction wcstoumax
-
-    syntax keyword cppSTLtype nanoseconds
-    syntax keyword cppSTLtype microseconds
-    syntax keyword cppSTLtype milliseconds
-    syntax keyword cppSTLtype seconds
-    syntax keyword cppSTLtype minutes
-    syntax keyword cppSTLtype hours
-
-    "raw string literals
-    syntax region cppRawString matchgroup=cppRawDelimiter start=@\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(@ end=/)\z1"/ contains=@Spell
-
-    syn match cNumber "0b[01]\+"
-endif " C++11
-
-if !exists("cpp_no_cpp14")
-    "dynarray
-    syntax keyword cppSTLtype dynarray
-
-    "thread
-    syntax keyword cppSTLtype shared_mutex
-    syntax keyword cppSTLtype shared_lock
-
-    "memory
-    syntax keyword cppSTLfunction make_unique
 endif " C++14
 
-if !exists("cpp_no_boost")
-    "optional is not a part of C++14 anymore
-    syntax keyword cppSTLtype optional
-    "syntax keyword cppSTLfunction value
-    syntax keyword cppSTLfunction value_or
-    syntax keyword cppSTLfunction make_optional
 
+if !exists("cpp_no_cpp17")
+    " algorithm
+    syntax keyword cppSTLfunction clamp
+    syntax keyword cppSTLfunction for_each_n
+
+    " any
+    syntax keyword cppSTLtype any
+    syntax keyword cppSTLexception bad_any_cast
+    syntax keyword cppSTLcast any_cast
+    syntax keyword cppSTLfunction make_any
+
+    " array
+    syntax keyword cppSTLfunction to_array
+    syntax keyword cppSTLfunction make_array
+
+    " atomic
+    syntax keyword cppSTLconstant is_always_lock_free
+
+    " chrono
+    syntax keyword cppSTLbool treat_as_floating_point_v
+
+    " cmath
+    syntax keyword cppSTLfunction assoc_laguerre assoc_laguerref assoc_laguerrel
+    syntax keyword cppSTLfunction assoc_legendre assoc_legendref assoc_legendrel
+    syntax keyword cppSTLfunction beta betaf betal
+    syntax keyword cppSTLfunction comp_ellint_1 comp_ellint_1f comp_ellint_1l
+    syntax keyword cppSTLfunction comp_ellint_2 comp_ellint_2f comp_ellint_2l
+    syntax keyword cppSTLfunction comp_ellint_3 comp_ellint_3f comp_ellint_3l
+    syntax keyword cppSTLfunction cyl_bessel_i cyl_bessel_if cyl_bessel_il
+    syntax keyword cppSTLfunction cyl_bessel_j cyl_bessel_jf cyl_bessel_jl
+    syntax keyword cppSTLfunction cyl_bessel_k cyl_bessel_kf cyl_bessel_kl
+    syntax keyword cppSTLfunction cyl_neumann cyl_neumannf cyl_neumannl
+    syntax keyword cppSTLfunction ellint_1 ellint_1f ellint_1l
+    syntax keyword cppSTLfunction ellint_2 ellint_2f ellint_2l
+    syntax keyword cppSTLfunction ellint_3 ellint_3f ellint_3l
+    syntax keyword cppSTLfunction expint expintf expintl
+    syntax keyword cppSTLfunction hermite hermitef hermitel
+    syntax keyword cppSTLfunction legendre legendrefl egendrel
+    syntax keyword cppSTLfunction laguerre laguerref laguerrel
+    syntax keyword cppSTLfunction riemann_zeta riemann_zetaf riemann_zetal
+    syntax keyword cppSTLfunction sph_bessel sph_besself sph_bessell
+    syntax keyword cppSTLfunction sph_legendre sph_legendref sph_legendrel
+    syntax keyword cppSTLfunction sph_neumann sph_neumannf sph_neumannl
+
+    " cstdlib
+    syntax keyword cppSTLfunction aligned_alloc
+
+    " exception
+    syntax keyword cppSTLfunction uncaught_exceptions
+
+    " execution
+    syntax keyword cppSTLnamespace execution
+    syntax keyword cppSTLconstant seq par par_unseq
+    syntax keyword cppSTLbool is_execution_policy_v
+    syntax keyword cppSTLtype sequenced_policy
+    syntax keyword cppSTLtype parallel_policy
+    syntax keyword cppSTLtype parallel_unsequenced_policy
+    syntax keyword cppSTLtype is_execution_policy
+
+    " filesystem
+    syntax keyword cppSTLnamespace filesystem
+    syntax keyword cppSTLexception filesystem_error
+    syntax keyword cppSTLtype path
+    syntax keyword cppSTLtype directory_entry
+    syntax keyword cppSTLtype directory_iterator
+    syntax keyword cppSTLtype recursive_directory_iterator
+    syntax keyword cppSTLtype file_status
+    syntax keyword cppSTLtype space_info
+    syntax keyword cppSTLtype file_time_type
+    syntax keyword cppSTLenum file_type
+    syntax keyword cppSTLenum perms
+    syntax keyword cppSTLenum copy_options
+    syntax keyword cppSTLenum directory_options
+    syntax keyword cppSTLConstant preferred_separator
+    syntax keyword cppSTLconstant available
+    " Note: 'capacity' and 'free' are already set as cppSTLfunction
+    " syntax keyword cppSTLconstant capacity
+    " syntax keyword cppSTLconstant free
+    syntax keyword cppSTLfunction concat
+    syntax keyword cppSTLfunction make_preferred
+    syntax keyword cppSTLfunction remove_filename
+    syntax keyword cppSTLfunction replace_filename
+    syntax keyword cppSTLfunction replace_extension
+    syntax keyword cppSTLfunction native
+    syntax keyword cppSTLfunction string_type
+    " Note: wstring, u8string, u16string, u32string already set as cppSTLtype
+    " syntax keyword cppSTLfunction wstring
+    " syntax keyword cppSTLfunction u8string
+    " syntax keyword cppSTLfunction u16string
+    " syntax keyword cppSTLfunction u32string
+    syntax keyword cppSTLfunction generic_string
+    syntax keyword cppSTLfunction generic_wstring
+    syntax keyword cppSTLfunction generic_u8string
+    syntax keyword cppSTLfunction generic_u16string
+    syntax keyword cppSTLfunction generic_u32string
+    syntax keyword cppSTLfunction lexically_normal
+    syntax keyword cppSTLfunction lexically_relative
+    syntax keyword cppSTLfunction lexically_proximate
+    syntax keyword cppSTLfunction root_name
+    syntax keyword cppSTLfunction root_directory
+    syntax keyword cppSTLfunction root_path
+    syntax keyword cppSTLfunction relative_path
+    syntax keyword cppSTLfunction parent_path
+    " syntax keyword cppSTLfunction filename
+    syntax keyword cppSTLfunction stem
+    syntax keyword cppSTLfunction extension
+    syntax keyword cppSTLfunction has_root_name
+    syntax keyword cppSTLfunction has_root_directory
+    syntax keyword cppSTLfunction has_root_path
+    syntax keyword cppSTLfunction has_relative_path
+    syntax keyword cppSTLfunction has_parent_path
+    syntax keyword cppSTLfunction has_filename
+    syntax keyword cppSTLfunction has_stem
+    syntax keyword cppSTLfunction has_extension
+    syntax keyword cppSTLfunction is_absolute
+    syntax keyword cppSTLfunction is_relative
+    syntax keyword cppSTLfunction hash_value
+    syntax keyword cppSTLfunction u8path
+    syntax keyword cppSTLfunction path1
+    syntax keyword cppSTLfunction path2
+    " syntax keyword cppSTLfunction path
+    syntax keyword cppSTLfunction status
+    syntax keyword cppSTLfunction symlink_status
+    syntax keyword cppSTLfunction options
+    " syntax keyword cppSTLfunction depth
+    syntax keyword cppSTLfunction recursive_pending
+    syntax keyword cppSTLfunction disable_recursive_pending
+    " syntax keyword cppSTLfunction type
+    syntax keyword cppSTLfunction permissions
+    syntax keyword cppSTLfunction absolute
+    syntax keyword cppSTLfunction system_complete
+    syntax keyword cppSTLfunction canonical
+    syntax keyword cppSTLfunction weakly_canonical
+    syntax keyword cppSTLfunction relative
+    syntax keyword cppSTLfunction proximate
+    syntax keyword cppSTLfunction copy_file
+    syntax keyword cppSTLfunction copy_symlink
+    syntax keyword cppSTLfunction create_directory
+    syntax keyword cppSTLfunction create_directories
+    syntax keyword cppSTLfunction create_hard_link
+    syntax keyword cppSTLfunction create_symlink
+    syntax keyword cppSTLfunction create_directory_symlink
+    syntax keyword cppSTLfunction current_path
+    " syntax keyword cppSTLfunction exists
+    syntax keyword cppSTLfunction file_size
+    syntax keyword cppSTLfunction hard_link_count
+    syntax keyword cppSTLfunction last_write_time
+    syntax keyword cppSTLfunction read_symlink
+    syntax keyword cppSTLfunction remove_all
+    syntax keyword cppSTLfunction resize_file
+    syntax keyword cppSTLfunction space
+    syntax keyword cppSTLfunction temp_directory_path
+    syntax keyword cppSTLfunction is_block_file
+    syntax keyword cppSTLfunction is_character_file
+    syntax keyword cppSTLfunction is_directory
+    syntax keyword cppSTLfunction is_fifo
+    syntax keyword cppSTLfunction is_other
+    syntax keyword cppSTLfunction is_regular_file
+    syntax keyword cppSTLfunction is_socket
+    syntax keyword cppSTLfunction is_symlink
+    syntax keyword cppSTLfunction status_known
+    " Note: 'is_empty' already set as cppSTLtype
+    " syntax keyword cppSTLfunction is_empty
+
+    " functional
+    syntax keyword cppSTLtype default_order
+    syntax keyword cppSTLtype default_order_t
+    syntax keyword cppSTLtype default_searcher
+    syntax keyword cppSTLtype boyer_moore_searcher
+    syntax keyword cppSTLtype boyer_moore_horspool_searcher
+    syntax keyword cppSTLbool is_bind_expression_v
+    syntax keyword cppSTLbool is_placeholder_v
+    syntax keyword cppSTLfunction not_fn
+    syntax keyword cppSTLfunction make_default_searcher
+    syntax keyword cppSTLfunction make_boyer_moore_searcher
+    syntax keyword cppSTLfunction make_boyer_moore_horspool_searcher
+    " syntax keyword cppSTLfunction invoke
+
+    " memory
+    syntax keyword cppSTLcast reinterpret_pointer_cast
+    syntax keyword cppSTLfunction uninitialized_move
+    syntax keyword cppSTLfunction uninitialized_move_n
+    syntax keyword cppSTLfunction uninitialized_default_construct
+    syntax keyword cppSTLfunction uninitialized_default_construct_n
+    syntax keyword cppSTLfunction uninitialized_value_construct
+    syntax keyword cppSTLfunction uninitialized_value_construct_n
+    syntax keyword cppSTLfunction destroy_at
+    syntax keyword cppSTLfunction destroy_n
+
+    " memory_resource
+    syntax keyword cppSTLtype polymorphic_allocator
+    syntax keyword cppSTLtype memory_resource
+    syntax keyword cppSTLtype synchronized_pool_resource
+    syntax keyword cppSTLtype unsynchronized_pool_resource
+    syntax keyword cppSTLtype pool_options
+    syntax keyword cppSTLtype monotonic_buffer_resource
+    syntax keyword cppSTLfunction upstream_resource
+    syntax keyword cppSTLfunction get_default_resource
+    syntax keyword cppSTLfunction new_default_resource
+    syntax keyword cppSTLfunction set_default_resource
+    syntax keyword cppSTLfunction null_memory_resource
+    syntax keyword cppSTLfunction allocate
+    syntax keyword cppSTLfunction deallocate
+    syntax keyword cppSTLfunction construct
+    syntax keyword cppSTLfunction destruct
+    syntax keyword cppSTLfunction resource
+    syntax keyword cppSTLfunction select_on_container_copy_construction
+    syntax keyword cppSTLfunction do_allocate
+    syntax keyword cppSTLfunction do_deallocate
+    syntax keyword cppSTLfunction do_is_equal
+
+    " new
+    syntax keyword cppSTLconstant hardware_destructive_interference_size
+    syntax keyword cppSTLconstant hardware_constructive_interference_size
+    syntax keyword cppSTLfunction launder
+
+    " numeric
+    syntax keyword cppSTLfunction gcd
+    syntax keyword cppSTLfunction lcm
+    syntax keyword cppSTLfunction exclusive_scan
+    syntax keyword cppSTLfunction inclusive_scan
+    syntax keyword cppSTLfunction transform_reduce
+    syntax keyword cppSTLfunction transform_exclusive_scan
+    syntax keyword cppSTLfunction transform_inclusive_scan
+    " syntax keyword cppSTLfunction reduce
+
+    " optional
+    syntax keyword cppSTLtype optional
+    syntax keyword cppSTLtype nullopt_t
+    syntax keyword cppSTLexception bad_optional_access
+    syntax keyword cppSTLconstant nullopt
+    syntax keyword cppSTLfunction make_optional
+    syntax keyword cppSTLfunction value_or
+    syntax keyword cppSTLfunction has_value
+    " syntax keyword cppSTLfunction value
+
+    " string_view
+    syntax keyword cppSTLtype basic_string_view
+    syntax keyword cppSTLtype string_view
+    syntax keyword cppSTLtype wstring_view
+    syntax keyword cppSTLtype u16string_view
+    syntax keyword cppSTLtype u32string_view
+    syntax keyword cppSTLfunction remove_prefix
+    syntax keyword cppSTLfunction remove_suffix
+
+    " system_error
+    syntax keyword cppSTLbool is_error_code_enum_v
+    syntax keyword cppSTLbool is_error_condition_enum_v
+
+    " thread
+    syntax keyword cppSTLtype shared_mutex
+
+    " tuple
+    syntax keyword cppSTLconstant tuple_size_v
+    syntax keyword cppSTLfunction make_from_tuple
+    " syntax keyword cppSTLfunction apply
+
+    " type_traits
+    syntax keyword cppSTLbool is_void_v
+    syntax keyword cppSTLbool is_null_pointer_v
+    syntax keyword cppSTLbool is_integral_v
+    syntax keyword cppSTLbool is_floating_point_v
+    syntax keyword cppSTLbool is_array_v
+    syntax keyword cppSTLbool is_enum_v
+    syntax keyword cppSTLbool is_union_v
+    syntax keyword cppSTLbool is_class_v
+    syntax keyword cppSTLbool is_function_v
+    syntax keyword cppSTLbool is_pointer_v
+    syntax keyword cppSTLbool is_lvalue_reference_v
+    syntax keyword cppSTLbool is_rvalue_reference_v
+    syntax keyword cppSTLbool is_member_object_pointer_v
+    syntax keyword cppSTLbool is_member_function_pointer_v
+    syntax keyword cppSTLbool is_fundamental_v
+    syntax keyword cppSTLbool is_arithmetic_v
+    syntax keyword cppSTLbool is_scalar_v
+    syntax keyword cppSTLbool is_object_v
+    syntax keyword cppSTLbool is_compound_v
+    syntax keyword cppSTLbool is_reference_v
+    syntax keyword cppSTLbool is_member_pointer_v
+    syntax keyword cppSTLbool is_const_v
+    syntax keyword cppSTLbool is_volatile_v
+    syntax keyword cppSTLbool is_trivial_v
+    syntax keyword cppSTLbool is_trivially_copyable_v
+    syntax keyword cppSTLbool is_standard_layout_v
+    syntax keyword cppSTLbool is_pod_v
+    syntax keyword cppSTLbool is_literal_type_v
+    syntax keyword cppSTLbool is_empty_v
+    syntax keyword cppSTLbool is_polymorphic_v
+    syntax keyword cppSTLbool is_abstract_v
+    syntax keyword cppSTLbool is_signed_v
+    syntax keyword cppSTLbool is_unsigned_v
+    syntax keyword cppSTLbool is_constructible_v
+    syntax keyword cppSTLbool is_trivially_constructible_v
+    syntax keyword cppSTLbool is_nothrow_constructible_v
+    syntax keyword cppSTLbool is_default_constructible_v
+    syntax keyword cppSTLbool is_trivially_default_constructible_v
+    syntax keyword cppSTLbool is_nothrow_default_constructible_v
+    syntax keyword cppSTLbool is_copy_constructible_v
+    syntax keyword cppSTLbool is_trivially_copy_constructible_v
+    syntax keyword cppSTLbool is_nothrow_copy_constructible_v
+    syntax keyword cppSTLbool is_move_constructible_v
+    syntax keyword cppSTLbool is_trivially_move_constructible_v
+    syntax keyword cppSTLbool is_nothrow_move_constructible_v
+    syntax keyword cppSTLbool is_assignable_v
+    syntax keyword cppSTLbool is_trivially_assignable_v
+    syntax keyword cppSTLbool is_nothrow_assignable_v
+    syntax keyword cppSTLbool is_copy_assignable_v
+    syntax keyword cppSTLbool is_trivially_copy_assignable_v
+    syntax keyword cppSTLbool is_nothrow_copy_assignable_v
+    syntax keyword cppSTLbool is_move_assignable_v
+    syntax keyword cppSTLbool is_trivially_move_assignable_v
+    syntax keyword cppSTLbool is_nothrow_move_assignable_v
+    syntax keyword cppSTLbool is_destructible_v
+    syntax keyword cppSTLbool is_trivially_destructible_v
+    syntax keyword cppSTLbool is_nothrow_destructible_v
+    syntax keyword cppSTLbool has_virtual_destructor_v
+    syntax keyword cppSTLbool is_same_v
+    syntax keyword cppSTLbool is_base_of_v
+    syntax keyword cppSTLbool is_convertible_v
+    syntax keyword cppSTLbool is_callable_v
+    syntax keyword cppSTLbool is_nowthrow_callable_v
+    syntax keyword cppSTLbool conjunction_v
+    syntax keyword cppSTLbool disjunction_v
+    syntax keyword cppSTLbool negation_v
+    syntax keyword cppSTLconstant alignment_of_v
+    syntax keyword cppSTLconstant rank_v
+    syntax keyword cppSTLconstant extent_v
+    syntax keyword cppSTLtype bool_constant
+    syntax keyword cppSTLtype is_callable
+    syntax keyword cppSTLtype is_nowthrow_callable
+    syntax keyword cppSTLtype conjunction
+    syntax keyword cppSTLtype disjunction
+    syntax keyword cppSTLtype negation
+
+    " unordered_map, unordered_set, unordered_multimap, unordered_multiset
+    syntax keyword cppSTLtype node_type
+    syntax keyword cppSTLtype insert_return_type
+    syntax keyword cppSTLfunction try_emplace
+    syntax keyword cppSTLfunction insert_or_assign
+    syntax keyword cppSTLfunction extract
+
+    " utility
+    syntax keyword cppSTLtype in_place_tag
+    syntax keyword cppSTLtype in_place_t
+    syntax keyword cppSTLtype in_place_type_t
+    syntax keyword cppSTLtype in_place_index_t
+    syntax keyword cppSTLfunction in_place
+    syntax keyword cppSTLfunction as_const
+
+    " variant
+    syntax keyword cppSTLtype variant
+    syntax keyword cppSTLtype monostate
+    syntax keyword cppSTLtype variant_size
+    syntax keyword cppSTLtype variant_alternative
+    syntax keyword cppSTLtype variant_alternative_t
+    syntax keyword cppSTLconstant variant_size_v
+    syntax keyword cppSTLconstant variant_npos
+    syntax keyword cppSTLexception bad_variant_access
+    syntax keyword cppSTLfunction valueless_by_exception
+    syntax keyword cppSTLfunction holds_alternative
+    syntax keyword cppSTLfunction get_if
+    syntax keyword cppSTLfunction visit
+    " syntax keyword cppSTLfunction index
+endif " C++17
+
+
+if exists('g:cpp_concepts_highlight') && g:cpp_concepts_highlight
+    syntax keyword cppStatement concept
+    syntax keyword cppStorageClass requires
+    syntax keyword cppSTLtype DefaultConstructible
+    syntax keyword cppSTLtype MoveConstructible
+    syntax keyword cppSTLtype CopyConstructible
+    syntax keyword cppSTLtype MoveAssignable
+    syntax keyword cppSTLtype CopyAssignable
+    syntax keyword cppSTLtype Destructible
+    syntax keyword cppSTLtype TriviallyCopyable
+    syntax keyword cppSTLtype TrivialType
+    syntax keyword cppSTLtype StandardLayoutType
+    syntax keyword cppSTLtype PODType
+    syntax keyword cppSTLtype EqualityComparable
+    syntax keyword cppSTLtype LessThanComparable
+    syntax keyword cppSTLtype Swappable
+    syntax keyword cppSTLtype ValueSwappable
+    syntax keyword cppSTLtype NullablePointer
+    syntax keyword cppSTLtype Hash
+    syntax keyword cppSTLtype Allocator
+    syntax keyword cppSTLtype FunctionObject
+    syntax keyword cppSTLtype Callable
+    syntax keyword cppSTLtype Predicate
+    syntax keyword cppSTLtype BinaryPredicate
+    syntax keyword cppSTLtype Compare
+    syntax keyword cppSTLtype Container
+    syntax keyword cppSTLtype ReversibleContainer
+    syntax keyword cppSTLtype AllocatorAwareContainer
+    syntax keyword cppSTLtype SequenceContainer
+    syntax keyword cppSTLtype ContiguousContainer
+    syntax keyword cppSTLtype AssociativeContainer
+    syntax keyword cppSTLtype UnorderedAssociativeContainer
+    syntax keyword cppSTLtype DefaultInsertable
+    syntax keyword cppSTLtype CopyInsertable
+    syntax keyword cppSTLtype CopyInsertable
+    syntax keyword cppSTLtype MoveInsertable
+    syntax keyword cppSTLtype EmplaceConstructible
+    syntax keyword cppSTLtype Erasable
+    syntax keyword cppSTLtype Iterator
+    syntax keyword cppSTLtype InputIterator
+    syntax keyword cppSTLtype OutputIterator
+    syntax keyword cppSTLtype ForwardIterator
+    syntax keyword cppSTLtype BidirectionalIterator
+    syntax keyword cppSTLtype RandomAccessIterator
+    syntax keyword cppSTLtype ContiguousIterator
+    syntax keyword cppSTLtype UnformattedInputFunction
+    syntax keyword cppSTLtype FormattedInputFunction
+    syntax keyword cppSTLtype UnformattedOutputFunction
+    syntax keyword cppSTLtype FormattedOutputFunction
+    syntax keyword cppSTLtype SeedSequence
+    syntax keyword cppSTLtype UniformRandomBitGenerator
+    syntax keyword cppSTLtype RandomNumberEngine
+    syntax keyword cppSTLtype RandomNumberEngineAdaptor
+    syntax keyword cppSTLtype RandomNumberDistribution
+    syntax keyword cppSTLtype BasicLockable
+    syntax keyword cppSTLtype Lockable
+    syntax keyword cppSTLtype TimedLockable
+    syntax keyword cppSTLtype Mutex
+    syntax keyword cppSTLtype TimedMutex
+    syntax keyword cppSTLtype SharedMutex
+    syntax keyword cppSTLtype SharedTimedMutex
+    syntax keyword cppSTLtype UnaryTypeTrait
+    syntax keyword cppSTLtype BinaryTypeTrait
+    syntax keyword cppSTLtype TransformationTrait
+    syntax keyword cppSTLtype Clock
+    syntax keyword cppSTLtype TrivialClock
+    syntax keyword cppSTLtype CharTraits
+    syntax keyword cppSTLtype pos_type
+    syntax keyword cppSTLtype off_type
+    syntax keyword cppSTLtype BitmaskType
+    syntax keyword cppSTLtype NumericType
+    syntax keyword cppSTLtype RegexTraits
+    syntax keyword cppSTLtype LiteralType
+endif " C++ concepts
+
+
+if !exists("cpp_no_boost")
     syntax keyword cppSTLnamespace boost
     syntax keyword cppSTLcast lexical_cast
-endif " Boost
+endif " boost
+
 
 " Default highlighting
 if version >= 508 || !exists("did_cpp_syntax_inits")
@@ -1407,6 +1952,9 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   else
     command -nargs=+ HiLink hi def link <args>
   endif
+  HiLink cppSTLbool         Boolean
+  HiLink cppStorageClass    StorageClass
+  HiLink cppStatement       Statement
   HiLink cppSTLfunction     Function
   HiLink cppSTLfunctional   Typedef
   HiLink cppSTLconstant     Constant
@@ -1418,7 +1966,7 @@ if version >= 508 || !exists("did_cpp_syntax_inits")
   HiLink cppSTLenum         Typedef
   HiLink cppSTLios          Function
   HiLink cppSTLcast         Statement " be consistent with official syntax
-  HiLink cppRawString       String 
+  HiLink cppRawString       String
   HiLink cppRawDelimiter    Delimiter
   delcommand HiLink
 endif


### PR DESCRIPTION
First of all, everything has been restructured. Now it's ordered
alphabetically according to the header where the type/function/variable
is defined in. This makes it easier to add or comment something out.
Some functions are commented out. These are functions that have simple
names and might collide with user-defined types (e.g. data, index, etc.)

I think C++14 should be complete now. There were many helper types
missing (the ones ending with _t).

Everything from C++17 that's on cppreference.com was added. This
includes: any, variant, optional, filesystem, memory_resource and many
more. C++17 introduced a lot of helper variable templates (like
is_same_v). If the variable is a bool, then it will be highlighted as a
Boolean. If the variable is a std::size_t, it will be highlighted as a
Constant.

Concepts didn't make it into C++17, but they are definitively coming.
All the named requirements found on cppreference.com have been included.