### PR TITLE
fix cCustomParen breaking PreProc

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -19,7 +19,7 @@
 "  Highlight function names.
 " -----------------------------------------------------------------------------
 if !exists('g:cpp_no_function_highlight')
-    syn match    cCustomParen    "(" contains=cParen contains=cCppParen
+    syn match    cCustomParen    transparent "(" contains=cParen contains=cCppParen
     syn match    cCustomFunc     "\w\+\s*(\@=" contains=cCustomParen
     hi def link cCustomFunc  Function
 endif

--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -35,7 +35,7 @@
 
 " Functions
 if !exists('g:cpp_no_function_highlight')
-    syn match   cCustomParen    "(" contains=cParen contains=cCppParen
+    syn match   cCustomParen    transparent "(" contains=cParen contains=cCppParen
     syn match   cCustomFunc     "\w\+\s*(\@="
     hi def link cCustomFunc  Function
 endif

--- a/test/color2.cpp
+++ b/test/color2.cpp
@@ -4,6 +4,10 @@
 // Note: the template functions break with
 // let g:cpp_experimental_template_highlight = 1
 
+#if !(defined _WIN32 || defined WINDOWS)
+#include <win.h>
+#endif
+
 class Class {
     Class(int val): value(val) {
     };


### PR DESCRIPTION
This PR makes cCustomParen transparent to prevent it from breaking highlighting of its containers.

Before:
![pre-b](https://user-images.githubusercontent.com/646121/31324243-b1f2c234-ac65-11e7-8445-2647cc91a08d.png)


After:
![pre-a](https://user-images.githubusercontent.com/646121/31324240-aa96f0be-ac65-11e7-9711-02c2eaef9a71.png)
