### PR TITLE
Don't color floats as member variables

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -30,7 +30,7 @@ endif
 if exists('g:cpp_member_variable_highlight') && g:cpp_member_variable_highlight
     syn match   cCustomDot    "\." contained
     syn match   cCustomPtr    "->" contained
-    syn match   cCustomMemVar "\(\.\|->\)\w\+" contains=cCustomDot,cCustomPtr
+    syn match   cCustomMemVar "\(\.\|->\)\h\w*" contains=cCustomDot,cCustomPtr
     hi def link cCustomMemVar Function
 endif
 

--- a/test/color2.cpp
+++ b/test/color2.cpp
@@ -28,6 +28,7 @@ void Class::Function(double variable) {
 }
 
 void func<std::map<std::string, std::string<double>>>() {
+    int a = .4;
     std::cout << "output" << std::endl;
 }
 


### PR DESCRIPTION
Fix float coloring

Before:
![float-b](https://user-images.githubusercontent.com/646121/31324275-f0496434-ac65-11e7-8705-810bb969e5ac.png)

After:
![float-a](https://user-images.githubusercontent.com/646121/31324277-fae66acc-ac65-11e7-9ab6-bb78645bd78c.png)
